### PR TITLE
Add player-shop protection toggle (default enabled)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.skyblockexp</groupId>
     <artifactId>ezshops</artifactId>
-    <version>2.1.3</version>
+    <version>2.2.0</version>
     <name>EzShops Plugin</name>
     <description>Standalone plugin providing the Skyblock shop command and sign shops.</description>
     <packaging>jar</packaging>

--- a/src/main/java/com/skyblockexp/ezshops/config/PlayerShopConfiguration.java
+++ b/src/main/java/com/skyblockexp/ezshops/config/PlayerShopConfiguration.java
@@ -33,6 +33,7 @@ public final class PlayerShopConfiguration {
     private final boolean enabled;
     private final Set<String> headerTokens;
     private final boolean requireStockOnCreation;
+    private final boolean protectionEnabled;
     private final int minQuantity;
     private final int maxQuantity;
     private final double minPrice;
@@ -41,11 +42,12 @@ public final class PlayerShopConfiguration {
     private final PlayerShopMessages messages;
 
     private PlayerShopConfiguration(boolean enabled, Set<String> headerTokens, boolean requireStockOnCreation,
-            int minQuantity, int maxQuantity, double minPrice, double maxPrice, SignFormat signFormat,
+            boolean protectionEnabled, int minQuantity, int maxQuantity, double minPrice, double maxPrice, SignFormat signFormat,
             PlayerShopMessages messages) {
         this.enabled = enabled;
         this.headerTokens = headerTokens;
         this.requireStockOnCreation = requireStockOnCreation;
+        this.protectionEnabled = protectionEnabled;
         this.minQuantity = minQuantity;
         this.maxQuantity = maxQuantity;
         this.minPrice = minPrice;
@@ -106,13 +108,15 @@ public final class PlayerShopConfiguration {
 
         PlayerShopMessages playerMessages = PlayerShopMessages.from(section.getConfigurationSection("messages"));
 
-        return new PlayerShopConfiguration(enabled, normalizedHeaders, requireStock, minQuantity, maxQuantity, minPrice,
-                maxPrice, signFormat, playerMessages);
+        boolean protection = section.getBoolean("protection-enabled", true);
+
+        return new PlayerShopConfiguration(enabled, normalizedHeaders, requireStock, protection, minQuantity, maxQuantity, minPrice,
+            maxPrice, signFormat, playerMessages);
     }
 
     public static PlayerShopConfiguration defaults() {
-        return new PlayerShopConfiguration(true, Collections.singleton(DEFAULT_HEADER), true, 1, 0, 0.0d, 0.0d,
-                SignFormat.defaults(), PlayerShopMessages.defaults());
+        return new PlayerShopConfiguration(true, Collections.singleton(DEFAULT_HEADER), true, true, 1, 0, 0.0d, 0.0d,
+            SignFormat.defaults(), PlayerShopMessages.defaults());
     }
 
     public boolean enabled() {
@@ -129,6 +133,10 @@ public final class PlayerShopConfiguration {
 
     public boolean requireStockOnCreation() {
         return requireStockOnCreation;
+    }
+
+    public boolean protectionEnabled() {
+        return protectionEnabled;
     }
 
     public int minQuantity() {

--- a/src/main/java/com/skyblockexp/ezshops/playershop/PlayerShopListener.java
+++ b/src/main/java/com/skyblockexp/ezshops/playershop/PlayerShopListener.java
@@ -133,14 +133,16 @@ public final class PlayerShopListener implements Listener {
         if (shop == null) {
             return;
         }
-        if (shop.ownerId().equals(player.getUniqueId())) {
-            return;
+        if (configuration.protectionEnabled()) {
+            if (shop.ownerId().equals(player.getUniqueId())) {
+                return;
+            }
+            if (player.hasPermission(PlayerShopManager.PERMISSION_ADMIN)) {
+                return;
+            }
+            event.setCancelled(true);
+            player.sendMessage(messages.chestAccessDenied());
         }
-        if (player.hasPermission(PlayerShopManager.PERMISSION_ADMIN)) {
-            return;
-        }
-        event.setCancelled(true);
-        player.sendMessage(messages.chestAccessDenied());
     }
 
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
@@ -155,10 +157,12 @@ public final class PlayerShopListener implements Listener {
         }
         Player player = event.getPlayer();
         boolean isOwner = shop.ownerId().equals(player.getUniqueId());
-        if (!isOwner && !player.hasPermission(PlayerShopManager.PERMISSION_ADMIN)) {
-            player.sendMessage(messages.breakDenied());
-            event.setCancelled(true);
-            return;
+        if (configuration.protectionEnabled()) {
+            if (!isOwner && !player.hasPermission(PlayerShopManager.PERMISSION_ADMIN)) {
+                player.sendMessage(messages.breakDenied());
+                event.setCancelled(true);
+                return;
+            }
         }
         manager.removeShop(shop);
         manager.saveShops();

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -31,6 +31,9 @@ player-shops:
   # Recognized first-line tokens that trigger a player shop sign.
   headers:
     - "[playershop]"
+  # When true, other players cannot open or break player shop chests/signs.
+  # Set to false to allow other players to open the chest and break the sign.
+  protection-enabled: true
   # When true, players must have enough stock for the first sale to finish
   # setup; otherwise the sign activates but will show as out of stock until
   # restocked.


### PR DESCRIPTION
- Added toggle in configuration to disable player-shop protection
```yaml
# When true, other players cannot open or break player shop chests/signs.
# Set to false to allow other players to open the chest and break the sign.
protection-enabled: true
```