### PR TITLE
feat: replace hardcoded back-button config with configurable GUI buttons

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>32.1.2-jre</version>
-            <scope>test</scope>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>${mockbukkit.groupId}</groupId>
@@ -202,6 +202,9 @@
                 <configuration>
                     <source>21</source>
                     <target>21</target>
+                    <compilerArgs>
+                        <arg>-Xlint:-processing</arg>
+                    </compilerArgs>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/java/com/skyblockexp/ezshops/gui/ShopMenu.java
+++ b/src/main/java/com/skyblockexp/ezshops/gui/ShopMenu.java
@@ -18,6 +18,7 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import org.bukkit.Bukkit;
+import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.entity.Player;
@@ -55,6 +56,10 @@ public class ShopMenu implements Listener {
     private final NamespacedKey itemKey;
     private final NamespacedKey actionKey;
     private final NamespacedKey quantityKey;
+    private final NamespacedKey soundKey;
+    private final NamespacedKey soundVolumeKey;
+    private final NamespacedKey soundPitchKey;
+    private final NamespacedKey commandKey;
     private final ShopInventoryComposer inventoryComposer;
     private final ConcurrentMap<UUID, PendingTransaction> pendingCustomInputs;
     private final ShopMessageConfiguration.GuiMessages guiMessages;
@@ -84,6 +89,10 @@ public class ShopMenu implements Listener {
         this.itemKey = new NamespacedKey(plugin, "shop_item");
         this.actionKey = new NamespacedKey(plugin, "shop_action");
         this.quantityKey = new NamespacedKey(plugin, "shop_quantity");
+        this.soundKey = new NamespacedKey(plugin, "shop_sound");
+        this.soundVolumeKey = new NamespacedKey(plugin, "shop_sound_volume");
+        this.soundPitchKey = new NamespacedKey(plugin, "shop_sound_pitch");
+        this.commandKey = new NamespacedKey(plugin, "shop_command");
         this.inventoryComposer = new ShopInventoryComposer(plugin, pricingManager, transactionService, categoryKey,
                 itemKey, actionKey, quantityKey, guiMessages);
         this.pendingCustomInputs = new ConcurrentHashMap<>();
@@ -210,6 +219,38 @@ public class ShopMenu implements Listener {
         }
 
         PersistentDataContainer container = CompatibilityUtil.getPersistentDataContainer(meta);
+
+        // Dispatch configurable button actions (valid in any menu type)
+        String action = CompatibilityUtil.get(container, actionKey, PersistentDataType.STRING);
+        if (ShopInventoryComposer.ACTION_CLOSE.equalsIgnoreCase(action)) {
+            player.closeInventory();
+            return;
+        }
+        if (ShopInventoryComposer.ACTION_OPEN_MAIN_MENU.equalsIgnoreCase(action)) {
+            plugin.getServer().getScheduler().runTask(plugin, () -> openMainMenu(player));
+            return;
+        }
+        if (ShopInventoryComposer.ACTION_PLAY_SOUND.equalsIgnoreCase(action)) {
+            String soundName = CompatibilityUtil.get(container, soundKey, PersistentDataType.STRING);
+            if (soundName != null) {
+                Float volume = CompatibilityUtil.get(container, soundVolumeKey, PersistentDataType.FLOAT);
+                Float pitch = CompatibilityUtil.get(container, soundPitchKey, PersistentDataType.FLOAT);
+                Location loc = player.getLocation();
+                player.playSound(loc, soundName, volume != null ? volume : 1.0f, pitch != null ? pitch : 1.0f);
+            }
+            return;
+        }
+        if (ShopInventoryComposer.ACTION_RUN_COMMAND.equalsIgnoreCase(action)) {
+            String cmd = CompatibilityUtil.get(container, commandKey, PersistentDataType.STRING);
+            if (cmd != null) {
+                player.closeInventory();
+                String resolved = cmd.replace("{player}", player.getName());
+                plugin.getServer().getScheduler().runTask(plugin,
+                        () -> player.performCommand(resolved));
+            }
+            return;
+        }
+
         if (holder instanceof MainShopMenuHolder) {
             String categoryId = CompatibilityUtil.get(container, categoryKey, PersistentDataType.STRING);
             if (categoryId != null) {
@@ -232,7 +273,6 @@ public class ShopMenu implements Listener {
             return;
         }
 
-        String action = CompatibilityUtil.get(container, actionKey, PersistentDataType.STRING);
         if (ShopInventoryComposer.ACTION_BACK.equalsIgnoreCase(action)) {
             plugin.getServer().getScheduler().runTask(plugin, () -> openMainMenu((Player) event.getWhoClicked()));
             return;

--- a/src/main/java/com/skyblockexp/ezshops/gui/shop/CategoryShopMenuHolder.java
+++ b/src/main/java/com/skyblockexp/ezshops/gui/shop/CategoryShopMenuHolder.java
@@ -3,8 +3,11 @@ package com.skyblockexp.ezshops.gui.shop;
 import com.skyblockexp.ezshops.shop.ShopMenuLayout;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 
 public final class CategoryShopMenuHolder extends AbstractShopMenuHolder {
@@ -16,7 +19,8 @@ public final class CategoryShopMenuHolder extends AbstractShopMenuHolder {
     private final Map<Integer, ShopMenuLayout.Item> slotEntries = new HashMap<>();
     private int page;
 
-    public CategoryShopMenuHolder(UUID owner, ShopMenuLayout.Category category) {
+    public CategoryShopMenuHolder(UUID owner, ShopMenuLayout.Category category,
+            List<ShopMenuLayout.ConfigurableButton> globalDefaultButtons) {
         super(owner);
         this.category = category;
 
@@ -30,11 +34,24 @@ public final class CategoryShopMenuHolder extends AbstractShopMenuHolder {
             this.nextSlot = -1;
         }
 
+        // Merge buttons: global defaults first, then category-specific overrides
+        Map<String, ShopMenuLayout.ConfigurableButton> merged = new LinkedHashMap<>();
+        if (globalDefaultButtons != null) {
+            for (ShopMenuLayout.ConfigurableButton b : globalDefaultButtons) {
+                merged.put(b.id(), b);
+            }
+        }
+        for (ShopMenuLayout.ConfigurableButton b : category.buttons()) {
+            merged.put(b.id(), b);
+        }
+        Set<Integer> buttonSlots = new HashSet<>();
+        for (ShopMenuLayout.ConfigurableButton b : merged.values()) {
+            buttonSlots.add(b.slot());
+        }
+
         List<Integer> computedSlots = new ArrayList<>();
-        Integer backSlot = category.backButtonSlot();
-        int back = backSlot != null ? backSlot : -9999;
         for (int slot = 0; slot < inventorySize; slot++) {
-            if (slot == previousSlot || slot == nextSlot || slot == back) {
+            if (slot == previousSlot || slot == nextSlot || buttonSlots.contains(slot)) {
                 continue;
             }
             if (preserveLastRow && inventorySize >= 9 && slot >= inventorySize - 9) {

--- a/src/main/java/com/skyblockexp/ezshops/gui/shop/ShopInventoryComposer.java
+++ b/src/main/java/com/skyblockexp/ezshops/gui/shop/ShopInventoryComposer.java
@@ -9,6 +9,7 @@ import com.skyblockexp.ezshops.shop.ShopPrice;
 import com.skyblockexp.ezshops.shop.ShopPricingManager;
 import com.skyblockexp.ezshops.shop.ShopTransactionService;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.Optional;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -33,6 +34,10 @@ import org.bukkit.plugin.java.JavaPlugin;
 public class ShopInventoryComposer {
 
     public static final String ACTION_BACK = "back";
+    public static final String ACTION_CLOSE = "close";
+    public static final String ACTION_PLAY_SOUND = "play_sound";
+    public static final String ACTION_RUN_COMMAND = "run_command";
+    public static final String ACTION_OPEN_MAIN_MENU = "open_main_menu";
     public static final String ACTION_CUSTOM = "custom";
     public static final String ACTION_PREVIOUS = "previous";
     public static final String ACTION_NEXT = "next";
@@ -44,6 +49,10 @@ public class ShopInventoryComposer {
     private final NamespacedKey itemKey;
     private final NamespacedKey actionKey;
     private final NamespacedKey quantityKey;
+    private final NamespacedKey soundKey;
+    private final NamespacedKey commandKey;
+    private final NamespacedKey soundVolumeKey;
+    private final NamespacedKey soundPitchKey;
     private final ShopMessageConfiguration.GuiMessages guiMessages;
     private final ShopMessageConfiguration.GuiMessages.CommonMessages commonMessages;
     private final ShopMessageConfiguration.GuiMessages.MenuMessages menuMessages;
@@ -62,6 +71,10 @@ public class ShopInventoryComposer {
         this.itemKey = itemKey;
         this.actionKey = actionKey;
         this.quantityKey = quantityKey;
+        this.soundKey = new NamespacedKey(plugin, "shop_sound");
+        this.commandKey = new NamespacedKey(plugin, "shop_command");
+        this.soundVolumeKey = new NamespacedKey(plugin, "shop_sound_volume");
+        this.soundPitchKey = new NamespacedKey(plugin, "shop_sound_pitch");
         this.guiMessages = guiMessages;
         this.commonMessages = guiMessages.common();
         this.menuMessages = guiMessages.menus();
@@ -104,6 +117,8 @@ public class ShopInventoryComposer {
                 inventory.setItem(category.slot(), icon);
             }
         }
+
+        placeButtons(inventory, layout.mainMenuButtons(), List.of(), Map.of());
 
         player.openInventory(inventory);
         placeInventoryMarker(inventory);
@@ -232,7 +247,8 @@ public class ShopInventoryComposer {
         }
 
         ShopMenuLayout layout = pricingManager.getMenuLayout();
-        CategoryShopMenuHolder holder = new CategoryShopMenuHolder(player.getUniqueId(), category);
+        CategoryShopMenuHolder holder = new CategoryShopMenuHolder(player.getUniqueId(), category,
+                layout.defaultCategoryButtons());
         Inventory inventory = Bukkit.createInventory(holder, category.menuSize(), category.menuTitle());
         holder.setInventory(inventory);
 
@@ -375,24 +391,8 @@ public class ShopInventoryComposer {
             }
         }
 
-        ShopMenuLayout.ItemDecoration backButtonDecoration = category.backButton() != null ? category.backButton()
-                : layout.defaultBackButton();
-        int backSlot = category.backButtonSlot() != null ? category.backButtonSlot()
-                : clampSlot(layout.defaultBackButtonSlot(), inventory.getSize());
-        if (backButtonDecoration != null) {
-            ItemStack backButton = createItem(backButtonDecoration, Map.of("{category}", category.displayName()));
-            if (backButton != null) {
-                setPersistent(backButton, actionKey, ACTION_BACK);
-                inventory.setItem(backSlot, backButton);
-            }
-        } else {
-            ItemStack backButton = createPlaceholderItem(Material.ARROW, categoryMenuMessages.defaultBackTitle(),
-                    categoryMenuMessages.defaultBackLore(category.displayName()));
-            if (backButton != null) {
-                setPersistent(backButton, actionKey, ACTION_BACK);
-                inventory.setItem(backSlot, backButton);
-            }
-        }
+        placeButtons(inventory, category.buttons(), layout.defaultCategoryButtons(),
+                Map.of("{category}", category.displayName()));
 
         player.openInventory(inventory);
         placeInventoryMarker(inventory);
@@ -437,10 +437,12 @@ public class ShopInventoryComposer {
         setPersistent(custom, actionKey, ACTION_CUSTOM);
         inventory.setItem(22, custom);
 
-        ShopMenuLayout.ItemDecoration backDecoration = layout.defaultBackButton();
+        ShopMenuLayout.ConfigurableButton backBtn = layout.defaultCategoryButtons().stream()
+                .filter(b -> b.action() == ShopMenuLayout.ButtonAction.BACK)
+                .findFirst().orElse(null);
         ItemStack backItem;
-        if (backDecoration != null) {
-            backItem = createItem(backDecoration,
+        if (backBtn != null && backBtn.display() != null) {
+            backItem = createItem(backBtn.display(),
                     Map.of("{category}", category.displayName(), "{name}", category.displayName()));
         } else {
             backItem = createPlaceholderItem(Material.ARROW, quantityMenuMessages.backTitle(),
@@ -459,6 +461,63 @@ public class ShopInventoryComposer {
         // Marker removal: GUI detection now uses InventoryHolder exclusively.
         // No visible marker should be placed.
         return;
+    }
+
+    private void placeButtons(Inventory inventory, List<ShopMenuLayout.ConfigurableButton> categoryButtons,
+            List<ShopMenuLayout.ConfigurableButton> globalDefaults, Map<String, String> placeholders) {
+        // Merge: global defaults first, then category-specific overrides (by id)
+        Map<String, ShopMenuLayout.ConfigurableButton> merged = new LinkedHashMap<>();
+        for (ShopMenuLayout.ConfigurableButton b : globalDefaults) {
+            merged.put(b.id(), b);
+        }
+        for (ShopMenuLayout.ConfigurableButton b : categoryButtons) {
+            // If the category button has no display, inherit from the global button with same id
+            if (b.display() == null) {
+                ShopMenuLayout.ConfigurableButton global = merged.get(b.id());
+                if (global != null && global.display() != null) {
+                    b = new ShopMenuLayout.ConfigurableButton(b.id(), b.slot(), global.display(), b.action(),
+                            b.sound(), b.soundVolume(), b.soundPitch(), b.command());
+                }
+            }
+            merged.put(b.id(), b);
+        }
+        for (ShopMenuLayout.ConfigurableButton button : merged.values()) {
+            int slot = button.slot();
+            if (slot < 0 || slot >= inventory.getSize()) {
+                continue;
+            }
+            ItemStack item;
+            if (button.display() != null) {
+                item = createItem(button.display(), placeholders);
+            } else {
+                item = createDefaultButtonItem(button.action(), placeholders);
+            }
+            if (item == null) {
+                continue;
+            }
+            String actionStr = button.action().name().toLowerCase(Locale.ROOT);
+            setPersistent(item, actionKey, actionStr);
+            if (button.action() == ShopMenuLayout.ButtonAction.PLAY_SOUND && button.sound() != null) {
+                setPersistent(item, soundKey, button.sound());
+                setPersistent(item, soundVolumeKey, button.soundVolume());
+                setPersistent(item, soundPitchKey, button.soundPitch());
+            }
+            if (button.action() == ShopMenuLayout.ButtonAction.RUN_COMMAND && button.command() != null) {
+                setPersistent(item, commandKey, button.command());
+            }
+            inventory.setItem(slot, item);
+        }
+    }
+
+    private ItemStack createDefaultButtonItem(ShopMenuLayout.ButtonAction action, Map<String, String> placeholders) {
+        String category = placeholders.getOrDefault("{category}", "");
+        return switch (action) {
+            case BACK -> createPlaceholderItem(Material.ARROW, categoryMenuMessages.defaultBackTitle(),
+                    categoryMenuMessages.defaultBackLore(category));
+            case CLOSE -> createPlaceholderItem(Material.BARRIER, "Close", List.of());
+            case OPEN_MAIN_MENU -> createPlaceholderItem(Material.NETHER_STAR, "Main Menu", List.of());
+            case PLAY_SOUND, RUN_COMMAND -> null;
+        };
     }
 
     private void applyFill(Inventory inventory, ShopMenuLayout.ItemDecoration fill) {
@@ -846,6 +905,16 @@ public class ShopInventoryComposer {
         }
         PersistentDataContainer container = CompatibilityUtil.getPersistentDataContainer(meta);
         CompatibilityUtil.set(container, key, PersistentDataType.INTEGER, value);
+        item.setItemMeta(meta);
+    }
+
+    private void setPersistent(ItemStack item, NamespacedKey key, float value) {
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null) {
+            return;
+        }
+        PersistentDataContainer container = CompatibilityUtil.getPersistentDataContainer(meta);
+        CompatibilityUtil.set(container, key, PersistentDataType.FLOAT, value);
         item.setItemMeta(meta);
     }
 

--- a/src/main/java/com/skyblockexp/ezshops/shop/ShopMenuLayout.java
+++ b/src/main/java/com/skyblockexp/ezshops/shop/ShopMenuLayout.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Collections;
 import org.bukkit.Material;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.EntityType;
@@ -16,22 +17,23 @@ public final class ShopMenuLayout {
     private final String mainTitle;
     private final int mainSize;
     private final ItemDecoration mainFill;
-    private final ItemDecoration defaultBackButton;
-    private final int defaultBackButtonSlot;
+    private final List<ConfigurableButton> defaultCategoryButtons;
+    private final List<ConfigurableButton> mainMenuButtons;
     private final List<Category> categories;
 
     public ShopMenuLayout(String mainTitle, int mainSize, ItemDecoration mainFill,
-            ItemDecoration defaultBackButton, int defaultBackButtonSlot, List<Category> categories) {
+            List<ConfigurableButton> defaultCategoryButtons, List<ConfigurableButton> mainMenuButtons,
+            List<Category> categories) {
         this.mainTitle = Objects.requireNonNull(mainTitle, "mainTitle");
         this.mainSize = mainSize;
         this.mainFill = mainFill;
-        this.defaultBackButton = defaultBackButton;
-        this.defaultBackButtonSlot = defaultBackButtonSlot;
+        this.defaultCategoryButtons = defaultCategoryButtons == null ? List.of() : List.copyOf(defaultCategoryButtons);
+        this.mainMenuButtons = mainMenuButtons == null ? List.of() : List.copyOf(mainMenuButtons);
         this.categories = List.copyOf(categories);
     }
 
     public static ShopMenuLayout empty() {
-        return new ShopMenuLayout("Skyblock Shop", 27, null, null, 0, List.of());
+        return new ShopMenuLayout("Skyblock Shop", 27, null, List.of(), List.of(), List.of());
     }
 
     public String mainTitle() {
@@ -46,12 +48,12 @@ public final class ShopMenuLayout {
         return mainFill;
     }
 
-    public ItemDecoration defaultBackButton() {
-        return defaultBackButton;
+    public List<ConfigurableButton> defaultCategoryButtons() {
+        return defaultCategoryButtons;
     }
 
-    public int defaultBackButtonSlot() {
-        return defaultBackButtonSlot;
+    public List<ConfigurableButton> mainMenuButtons() {
+        return mainMenuButtons;
     }
 
     public List<Category> categories() {
@@ -67,15 +69,14 @@ public final class ShopMenuLayout {
         private final String menuTitle;
         private final int menuSize;
         private final ItemDecoration menuFill;
-        private final ItemDecoration backButton;
-        private final Integer backButtonSlot;
+        private final List<ConfigurableButton> buttons;
         private final boolean preserveLastRow;
         private final List<Item> items;
         private final CategoryRotation rotation;
         private final String command;
 
         public Category(String id, String displayName, ItemDecoration icon, int slot, String menuTitle, int menuSize,
-                ItemDecoration menuFill, ItemDecoration backButton, Integer backButtonSlot, boolean preserveLastRow, List<Item> items,
+                ItemDecoration menuFill, List<ConfigurableButton> buttons, boolean preserveLastRow, List<Item> items,
                 CategoryRotation rotation, String command) {
             this.id = Objects.requireNonNull(id, "id");
             this.displayName = Objects.requireNonNull(displayName, "displayName");
@@ -84,8 +85,7 @@ public final class ShopMenuLayout {
             this.menuTitle = Objects.requireNonNull(menuTitle, "menuTitle");
             this.menuSize = menuSize;
             this.menuFill = menuFill;
-            this.backButton = backButton;
-            this.backButtonSlot = backButtonSlot;
+            this.buttons = buttons == null ? List.of() : List.copyOf(buttons);
             this.preserveLastRow = preserveLastRow;
             this.items = List.copyOf(items);
             this.rotation = rotation;
@@ -120,12 +120,8 @@ public final class ShopMenuLayout {
             return menuFill;
         }
 
-        public ItemDecoration backButton() {
-            return backButton;
-        }
-
-        public Integer backButtonSlot() {
-            return backButtonSlot;
+        public List<ConfigurableButton> buttons() {
+            return buttons;
         }
 
         public boolean preserveLastRow() {
@@ -292,6 +288,81 @@ public final class ShopMenuLayout {
 
         public DeliveryType delivery() {
             return delivery;
+        }
+    }
+
+    public enum ButtonAction {
+        BACK,
+        CLOSE,
+        PLAY_SOUND,
+        RUN_COMMAND,
+        OPEN_MAIN_MENU;
+
+        public static ButtonAction fromConfig(String value) {
+            if (value == null || value.isBlank()) {
+                return null;
+            }
+            try {
+                return valueOf(value.trim().toUpperCase(Locale.ROOT));
+            } catch (IllegalArgumentException e) {
+                return null;
+            }
+        }
+    }
+
+    public static final class ConfigurableButton {
+
+        private final String id;
+        private final int slot;
+        private final ItemDecoration display;
+        private final ButtonAction action;
+        private final String sound;
+        private final float soundVolume;
+        private final float soundPitch;
+        private final String command;
+
+        public ConfigurableButton(String id, int slot, ItemDecoration display, ButtonAction action,
+                String sound, float soundVolume, float soundPitch, String command) {
+            this.id = Objects.requireNonNull(id, "id");
+            this.slot = slot;
+            this.display = display;
+            this.action = Objects.requireNonNull(action, "action");
+            this.sound = sound;
+            this.soundVolume = soundVolume;
+            this.soundPitch = soundPitch;
+            this.command = command;
+        }
+
+        public String id() {
+            return id;
+        }
+
+        public int slot() {
+            return slot;
+        }
+
+        public ItemDecoration display() {
+            return display;
+        }
+
+        public ButtonAction action() {
+            return action;
+        }
+
+        public String sound() {
+            return sound;
+        }
+
+        public float soundVolume() {
+            return soundVolume;
+        }
+
+        public float soundPitch() {
+            return soundPitch;
+        }
+
+        public String command() {
+            return command;
         }
     }
 

--- a/src/main/java/com/skyblockexp/ezshops/shop/ShopPricingManager.java
+++ b/src/main/java/com/skyblockexp/ezshops/shop/ShopPricingManager.java
@@ -54,8 +54,8 @@ public class ShopPricingManager {
     private String mainMenuTitle = "Skyblock Shop";
     private int mainMenuSize = 27;
     private ShopMenuLayout.ItemDecoration mainMenuFillDecoration = null;
-    private ShopMenuLayout.ItemDecoration defaultBackButtonDecoration = null;
-    private int defaultBackButtonSlot = 0;
+    private List<ShopMenuLayout.ConfigurableButton> defaultCategoryButtons = List.of();
+    private List<ShopMenuLayout.ConfigurableButton> mainMenuButtons = List.of();
 
     public ShopPricingManager(JavaPlugin plugin, DynamicPricingConfiguration dynamicConfiguration) {
         this.plugin = plugin;
@@ -79,8 +79,8 @@ public class ShopPricingManager {
         mainMenuTitle = "Skyblock Shop";
         mainMenuSize = 27;
         mainMenuFillDecoration = null;
-        defaultBackButtonDecoration = null;
-        defaultBackButtonSlot = 0;
+        defaultCategoryButtons = List.of();
+        mainMenuButtons = List.of();
 
         ensureDataFolder();
         if (dynamicStateFile.exists()) {
@@ -417,13 +417,18 @@ public class ShopPricingManager {
                         List.of()));
 
         ConfigurationSection categoryMenuSection = root.getConfigurationSection(CATEGORY_MENU_KEY);
-        defaultBackButtonDecoration = parseDecoration(
-                categoryMenuSection != null ? categoryMenuSection.getConfigurationSection("back-button") : null,
-                new ShopMenuLayout.ItemDecoration(Material.ARROW, 1,
-                        ChatColor.YELLOW + "\u2190 Back to Shop",
-                        List.of(ChatColor.GRAY + "Return to the main shop menu.")));
-        defaultBackButtonSlot = clampSlot(
-                categoryMenuSection != null ? categoryMenuSection.getInt("back-button-slot", 49) : 49, 54);
+        List<ShopMenuLayout.ConfigurableButton> parsedCategoryButtons = parseButtons(categoryMenuSection);
+        if (parsedCategoryButtons.isEmpty()) {
+            // Provide a built-in BACK button default so existing configs without explicit buttons still work
+            parsedCategoryButtons = List.of(new ShopMenuLayout.ConfigurableButton(
+                    "back", 49,
+                    new ShopMenuLayout.ItemDecoration(Material.ARROW, 1,
+                            ChatColor.YELLOW + "\u2190 Back to Shop",
+                            List.of(ChatColor.GRAY + "Return to the main shop menu.")),
+                    ShopMenuLayout.ButtonAction.BACK, null, 1.0f, 1.0f, null));
+        }
+        defaultCategoryButtons = parsedCategoryButtons;
+        mainMenuButtons = parseButtons(mainMenuSection);
 
         List<CategoryTemplate> templates = new ArrayList<>();
         ConfigurationSection categoriesSection = root.getConfigurationSection(CATEGORIES_KEY);
@@ -458,19 +463,7 @@ public class ShopPricingManager {
         int menuSize = normalizeSize(menuSection != null ? menuSection.getInt("size", 54) : 54);
         ShopMenuLayout.ItemDecoration menuFill = parseDecoration(
                 menuSection != null ? menuSection.getConfigurationSection("fill") : null, null);
-        ShopMenuLayout.ItemDecoration backButton = parseDecoration(
-                menuSection != null ? menuSection.getConfigurationSection("back-button") : null, null);
-
-        Integer backButtonSlot = null;
-        if (menuSection != null && menuSection.contains("back-button-slot")) {
-            int slotValue = menuSection.getInt("back-button-slot");
-            if (slotValue < 0 || slotValue >= menuSize) {
-                logger.warning("Ignoring back button slot " + slotValue + " for category '" + categoryId
-                        + "' because it is outside the menu bounds.");
-            } else {
-                backButtonSlot = slotValue;
-            }
-        }
+        List<ShopMenuLayout.ConfigurableButton> categoryButtons = parseButtons(menuSection);
 
         String rotationGroupId = section.getString("rotation-group");
         if (rotationGroupId != null && rotationGroupId.isBlank()) {
@@ -501,7 +494,7 @@ public class ShopPricingManager {
 
                 String command = section.getString("command", null);
                 return new CategoryTemplate(categoryId, displayName, icon, slot, menuTitle, menuSize, menuFill,
-                    backButton, backButtonSlot, preserveLastRow, List.copyOf(items), null, command);
+                    categoryButtons, preserveLastRow, List.copyOf(items), null, command);
         }
 
         ShopRotationDefinition definition = rotationDefinitions.get(rotationGroupId);
@@ -524,7 +517,7 @@ public class ShopPricingManager {
             }
                 String command = section.getString("command", null);
                 return new CategoryTemplate(categoryId, displayName, icon, slot, menuTitle, menuSize, menuFill,
-                    backButton, backButtonSlot, preserveLastRow, List.copyOf(items), null, command);
+                    categoryButtons, preserveLastRow, List.copyOf(items), null, command);
         }
 
         ConfigurationSection rotationDefaultsSection = section.getConfigurationSection("rotation-defaults");
@@ -561,8 +554,8 @@ public class ShopPricingManager {
         }
 
         RotationBinding rotation = new RotationBinding(rotationGroupId, defaultIcon, defaultMenuTitle, optionItems);
-        return new CategoryTemplate(categoryId, displayName, icon, slot, menuTitle, menuSize, menuFill, backButton,
-            backButtonSlot, preserveLastRow, List.of(), rotation, section.getString("command", null));
+        return new CategoryTemplate(categoryId, displayName, icon, slot, menuTitle, menuSize, menuFill, categoryButtons,
+            preserveLastRow, List.of(), rotation, section.getString("command", null));
     }
 
     private ShopMenuLayout rebuildMenuLayoutFromTemplates() {
@@ -573,8 +566,8 @@ public class ShopPricingManager {
                 categories.add(category);
             }
         }
-        return new ShopMenuLayout(mainMenuTitle, mainMenuSize, mainMenuFillDecoration, defaultBackButtonDecoration,
-                defaultBackButtonSlot, categories);
+        return new ShopMenuLayout(mainMenuTitle, mainMenuSize, mainMenuFillDecoration, defaultCategoryButtons,
+                mainMenuButtons, categories);
     }
 
     private ShopMenuLayout.Category buildCategoryFromTemplate(CategoryTemplate template) {
@@ -583,8 +576,8 @@ public class ShopPricingManager {
         }
         if (!template.isRotating()) {
             return new ShopMenuLayout.Category(template.id, template.displayName, template.icon, template.slot,
-                template.menuTitle, template.menuSize, template.menuFill, template.backButton,
-                template.backButtonSlot, template.preserveLastRow, template.staticItems, null, template.command);
+                template.menuTitle, template.menuSize, template.menuFill, template.buttons,
+                template.preserveLastRow, template.staticItems, null, template.command);
         }
 
         RotationBinding binding = template.rotation;
@@ -593,8 +586,8 @@ public class ShopPricingManager {
             logger.warning("Rotation group '" + binding.groupId() + "' is no longer available for category '"
                     + template.id + "'.");
                 return new ShopMenuLayout.Category(template.id, template.displayName, template.icon, template.slot,
-                    template.menuTitle, template.menuSize, template.menuFill, template.backButton,
-                    template.backButtonSlot, template.preserveLastRow, List.of(), null, template.command);
+                    template.menuTitle, template.menuSize, template.menuFill, template.buttons,
+                    template.preserveLastRow, List.of(), null, template.command);
         }
 
         String optionId = activeRotationOptions.getOrDefault(definition.id(), definition.defaultOptionId());
@@ -628,7 +621,7 @@ public class ShopPricingManager {
         ShopMenuLayout.CategoryRotation rotationState =
                 new ShopMenuLayout.CategoryRotation(definition.id(), optionId);
         return new ShopMenuLayout.Category(template.id, template.displayName, icon, template.slot, menuTitle,
-            template.menuSize, template.menuFill, template.backButton, template.backButtonSlot, template.preserveLastRow, items,
+            template.menuSize, template.menuFill, template.buttons, template.preserveLastRow, items,
             rotationState, template.command);
     }
 
@@ -1393,6 +1386,42 @@ public class ShopPricingManager {
         return slot;
     }
 
+    private List<ShopMenuLayout.ConfigurableButton> parseButtons(ConfigurationSection section) {
+        if (section == null) {
+            return List.of();
+        }
+        List<ShopMenuLayout.ConfigurableButton> buttons = new ArrayList<>();
+        for (String key : section.getKeys(false)) {
+            if (!section.isConfigurationSection(key)) {
+                continue;
+            }
+            ConfigurationSection btnSection = section.getConfigurationSection(key);
+            if (btnSection == null || !btnSection.contains("action")) {
+                continue;
+            }
+            String actionStr = btnSection.getString("action");
+            ShopMenuLayout.ButtonAction action = ShopMenuLayout.ButtonAction.fromConfig(actionStr);
+            if (action == null) {
+                logger.warning("Unknown button action '" + actionStr + "' for button '" + key + "' — skipping.");
+                continue;
+            }
+            int slot = btnSection.getInt("slot", -1);
+            if (slot < 0) {
+                logger.warning("Button '" + key + "' has no valid slot — skipping.");
+                continue;
+            }
+            ShopMenuLayout.ItemDecoration display = btnSection.contains("material")
+                    ? parseDecoration(btnSection, null) : null;
+            String sound = btnSection.getString("sound", null);
+            float soundVolume = (float) btnSection.getDouble("volume", 1.0);
+            float soundPitch = (float) btnSection.getDouble("pitch", 1.0);
+            String command = btnSection.getString("command", null);
+            buttons.add(new ShopMenuLayout.ConfigurableButton(key, slot, display, action,
+                    sound, soundVolume, soundPitch, command));
+        }
+        return buttons;
+    }
+
     private ShopMenuLayout.ItemDecoration parseDecoration(ConfigurationSection section,
             ShopMenuLayout.ItemDecoration fallback) {
         if (section == null) {
@@ -1469,8 +1498,7 @@ public class ShopPricingManager {
         private final String menuTitle;
         private final int menuSize;
         private final ShopMenuLayout.ItemDecoration menuFill;
-        private final ShopMenuLayout.ItemDecoration backButton;
-        private final Integer backButtonSlot;
+        private final List<ShopMenuLayout.ConfigurableButton> buttons;
         private final boolean preserveLastRow;
         private final List<ShopMenuLayout.Item> staticItems;
         private final RotationBinding rotation;
@@ -1478,7 +1506,7 @@ public class ShopPricingManager {
 
         private CategoryTemplate(String id, String displayName, ShopMenuLayout.ItemDecoration icon, int slot,
                 String menuTitle, int menuSize, ShopMenuLayout.ItemDecoration menuFill,
-                ShopMenuLayout.ItemDecoration backButton, Integer backButtonSlot, boolean preserveLastRow, List<ShopMenuLayout.Item> staticItems,
+                List<ShopMenuLayout.ConfigurableButton> buttons, boolean preserveLastRow, List<ShopMenuLayout.Item> staticItems,
                 RotationBinding rotation, String command) {
             this.id = Objects.requireNonNull(id, "id");
             this.displayName = Objects.requireNonNull(displayName, "displayName");
@@ -1487,8 +1515,7 @@ public class ShopPricingManager {
             this.menuTitle = Objects.requireNonNull(menuTitle, "menuTitle");
             this.menuSize = menuSize;
             this.menuFill = menuFill;
-            this.backButton = backButton;
-            this.backButtonSlot = backButtonSlot;
+            this.buttons = buttons == null ? List.of() : List.copyOf(buttons);
             this.preserveLastRow = preserveLastRow;
             this.staticItems = staticItems == null ? List.of() : List.copyOf(staticItems);
             this.rotation = rotation;

--- a/src/main/resources/shop/categories/daily_specials.yml
+++ b/src/main/resources/shop/categories/daily_specials.yml
@@ -19,7 +19,6 @@ categories:
       fill:
         material: WHITE_STAINED_GLASS_PANE
         display-name: "{translate:shop.common.menu.fill-display-name}"
-      back-button-slot: 49
     # Link this category to the rotation defined in shop/rotations/daily-specials.yml.
     rotation-group: daily-specials
     rotation-defaults:

--- a/src/main/resources/shop/categories/redstone.yml
+++ b/src/main/resources/shop/categories/redstone.yml
@@ -14,7 +14,9 @@ categories:
       fill:
         material: LIGHT_GRAY_STAINED_GLASS_PANE
         display-name: "{translate:shop.common.menu.fill-display-name}"
-      back-button-slot: 45
+      back:
+        slot: 45
+        action: BACK
     items:
       redstone_dust:
         material: REDSTONE

--- a/src/main/resources/shop/menu.yml
+++ b/src/main/resources/shop/menu.yml
@@ -9,9 +9,10 @@ main-menu:
     material: LIGHT_GRAY_STAINED_GLASS_PANE
     display-name: "{translate:shop.common.menu.fill-display-name}"
 category-menu:
-  back-button-slot: 49
-  back-button:
+  back:
+    slot: 49
     material: ARROW
     display-name: "{translate:shop.menu.category.back-display-name}"
     lore:
-    - "{translate:shop.menu.category.back-lore}"
+      - "{translate:shop.menu.category.back-lore}"
+    action: BACK

--- a/src/test/java/com/skyblockexp/ezshops/core/ShopGuiConfigurableFeaturesTest.java
+++ b/src/test/java/com/skyblockexp/ezshops/core/ShopGuiConfigurableFeaturesTest.java
@@ -29,8 +29,8 @@ public class ShopGuiConfigurableFeaturesTest extends AbstractEzShopsTest {
         // Build a simple menu layout with one category that has a command
         ShopMenuLayout.ItemDecoration icon = new ShopMenuLayout.ItemDecoration(Material.PAPER, 1, "Cat", List.of());
         ShopMenuLayout.Category category = new ShopMenuLayout.Category("testcat", "Test Cat", icon, 10,
-                "Test Menu", 27, null, null, null, false, List.of(), null, "say hello {player}");
-        ShopMenuLayout layout = new ShopMenuLayout("Test Shop", 27, null, null, 0, List.of(category));
+                "Test Menu", 27, null, List.of(), false, List.of(), null, "say hello {player}");
+        ShopMenuLayout layout = new ShopMenuLayout("Test Shop", 27, null, List.of(), List.of(), List.of(category));
 
         // inject layout into pricing manager
         java.lang.reflect.Field corePricingField = CoreShopComponent.class.getDeclaredField("pricingManager");
@@ -71,9 +71,10 @@ public class ShopGuiConfigurableFeaturesTest extends AbstractEzShopsTest {
         ShopMenuLayout.ItemDecoration icon = new ShopMenuLayout.ItemDecoration(Material.PAPER, 1, "Cat", List.of());
         ShopMenuLayout.ItemDecoration backDec = new ShopMenuLayout.ItemDecoration(Material.DIAMOND, 1, "Back", List.of("Go back"));
 
+        ShopMenuLayout.ConfigurableButton backBtn = new ShopMenuLayout.ConfigurableButton("back", 5, backDec, ShopMenuLayout.ButtonAction.BACK, null, 1.0f, 1.0f, null);
         ShopMenuLayout.Category category = new ShopMenuLayout.Category("testcat2", "Test Cat2", icon, 0,
-                "Category Menu", 27, null, backDec, Integer.valueOf(5), false, List.of(), null, null);
-        ShopMenuLayout layout = new ShopMenuLayout("Test Shop", 27, null, null, 0, List.of(category));
+                "Category Menu", 27, null, List.of(backBtn), false, List.of(), null, null);
+        ShopMenuLayout layout = new ShopMenuLayout("Test Shop", 27, null, List.of(), List.of(), List.of(category));
 
         java.lang.reflect.Field corePricingField = CoreShopComponent.class.getDeclaredField("pricingManager");
         corePricingField.setAccessible(true);
@@ -122,8 +123,8 @@ public class ShopGuiConfigurableFeaturesTest extends AbstractEzShopsTest {
         ShopMenuLayout.ItemDecoration icon = new ShopMenuLayout.ItemDecoration(Material.DIAMOND, 1, "It", List.of());
         ShopMenuLayout.Item item = new ShopMenuLayout.Item("diamond_item", Material.DIAMOND, icon, 0, 0, 1, 1,
                 new com.skyblockexp.ezshops.shop.ShopPrice(1.0, 1.0), ShopMenuLayout.ItemType.MATERIAL, null, java.util.Map.of(), 0);
-        ShopMenuLayout.Category category = new ShopMenuLayout.Category("catq", "CatQ", icon, 0, "CatQ Menu", 27, null, null, null, false, List.of(item), null, null);
-        ShopMenuLayout layout = new ShopMenuLayout("Test Shop", 27, null, null, 0, List.of(category));
+        ShopMenuLayout.Category category = new ShopMenuLayout.Category("catq", "CatQ", icon, 0, "CatQ Menu", 27, null, List.of(), false, List.of(item), null, null);
+        ShopMenuLayout layout = new ShopMenuLayout("Test Shop", 27, null, List.of(), List.of(), List.of(category));
 
         java.lang.reflect.Field corePricingField = CoreShopComponent.class.getDeclaredField("pricingManager");
         corePricingField.setAccessible(true);


### PR DESCRIPTION
Add support for defining arbitrary GUI buttons in YAML config via an action: field on any ConfigurationSection. Buttons support actions: BACK, CLOSE, PLAY_SOUND, RUN_COMMAND, OPEN_MAIN_MENU.

**Breaking change**: the back-button / back-button-slot keys in category
menu config are replaced by a button entry with action: BACK.

Changes:
- ShopMenuLayout: add `ButtonAction` enum and `ConfigurableButton` model; replace `defaultBackButton`/`defaultBackButtonSlot` fields with `defaultCategoryButtons` and `mainMenuButtons` lists; update `Category` to carry a buttons list instead of `backButton`/`backButtonSlot`
- `ShopPricingManager`: add `parseButtons()` helper that detects buttons by the presence of an action: key; fall back to a default `ARROW BACK` button at slot 49 when no buttons are configured; replace `CategoryTemplate` `backButton`/`backButtonSlot` fields with buttons list
- `CategoryShopMenuHolder`: accept `globalDefaultButtons` to merge with category buttons; exclude all button slots from item slot range
- `ShopInventoryComposer`: add `placeButtons()` that merges global and category-level buttons, creates default items per action type, and tags each item via `PersistentDataContainer` (shop_action, shop_sound, shop_command, shop_sound_volume, shop_sound_pitch); add ACTION_CLOSE, ACTION_PLAY_SOUND, ACTION_RUN_COMMAND, ACTION_OPEN_MAIN_MENU constants
- `ShopMenu`: dispatch CLOSE, OPEN_MAIN_MENU, PLAY_SOUND and RUN_COMMAND actions from inventory click events; support `{player}` placeholder in commands
- Config: migrate `menu.yml`, `redstone.yml` and `daily_specials.yml` to the new button syntax
- `pom.xml`: fix pre-existing compile error by moving guava from test to provided scope
- `ShopGuiConfigurableFeaturesTest`: update `Category`/`ShopMenuLayout` constructor calls to new signatures