### PR TITLE
30 quick sell inventory

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -213,6 +213,7 @@
                 <version>3.0.0-M8</version>
                 <configuration>
                     <useModulePath>false</useModulePath>
+                    <argLine>-Dnet.bytebuddy.experimental=true</argLine>
                 </configuration>
             </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.skyblockexp</groupId>
     <artifactId>ezshops</artifactId>
-    <version>2.3.1</version>
+    <version>2.4.0</version>
     <name>EzShops Plugin</name>
     <description>Standalone plugin providing the Skyblock shop command and sign shops.</description>
     <packaging>jar</packaging>

--- a/src/main/java/com/skyblockexp/ezshops/bootstrap/CoreShopComponent.java
+++ b/src/main/java/com/skyblockexp/ezshops/bootstrap/CoreShopComponent.java
@@ -128,7 +128,11 @@ public final class CoreShopComponent implements PluginComponent {
         priceCommand = new PriceCommand(pricingManager, transactionService, commandMessages.price());
 
         boolean quickSellEnabled = plugin.getConfig().getBoolean("quick-sell.enabled", true);
-        quickSellMenu = new QuickSellMenu(pricingManager, transactionService, commandMessages.sell());
+        String confirmSound = plugin.getConfig().getString("quick-sell.confirm-sound.name", "entity.experience_orb.pickup");
+        float confirmSoundVolume = (float) plugin.getConfig().getDouble("quick-sell.confirm-sound.volume", 1.0);
+        float confirmSoundPitch = (float) plugin.getConfig().getDouble("quick-sell.confirm-sound.pitch", 1.0);
+        quickSellMenu = new QuickSellMenu(pricingManager, transactionService, commandMessages.sell(),
+                confirmSound, confirmSoundVolume, confirmSoundPitch);
         sellCommand = new SellCommand(quickSellMenu, commandMessages.sell(), quickSellEnabled);
 
         PluginManager pluginManager = plugin.getServer().getPluginManager();

--- a/src/main/java/com/skyblockexp/ezshops/bootstrap/CoreShopComponent.java
+++ b/src/main/java/com/skyblockexp/ezshops/bootstrap/CoreShopComponent.java
@@ -2,9 +2,11 @@ package com.skyblockexp.ezshops.bootstrap;
 
 import com.skyblockexp.ezshops.shop.command.PriceCommand;
 import com.skyblockexp.ezshops.shop.command.PricingAdminCommand;
+import com.skyblockexp.ezshops.shop.command.SellCommand;
 import com.skyblockexp.ezshops.shop.command.SellHandCommand;
 import com.skyblockexp.ezshops.shop.command.SellInventoryCommand;
 import com.skyblockexp.ezshops.shop.command.ShopCommand;
+import com.skyblockexp.ezshops.gui.quicksell.QuickSellMenu;
 import com.skyblockexp.ezshops.EzShopsPlugin;
 import com.skyblockexp.ezshops.config.ShopMessageConfiguration;
 import com.skyblockexp.ezshops.gui.IslandLevelProvider;
@@ -52,6 +54,8 @@ public final class CoreShopComponent implements PluginComponent {
     private ShopCommand shopCommand;
     private SellHandCommand sellHandCommand;
     private SellInventoryCommand sellInventoryCommand;
+    private SellCommand sellCommand;
+    private QuickSellMenu quickSellMenu;
     private PriceCommand priceCommand;
     private ShopPriceService shopPriceService;
     private ShopTemplateService shopTemplateService;
@@ -123,11 +127,17 @@ public final class CoreShopComponent implements PluginComponent {
         sellInventoryCommand = new SellInventoryCommand(transactionService, commandMessages.sellInventory());
         priceCommand = new PriceCommand(pricingManager, transactionService, commandMessages.price());
 
+        boolean quickSellEnabled = plugin.getConfig().getBoolean("quick-sell.enabled", true);
+        quickSellMenu = new QuickSellMenu(pricingManager, transactionService, commandMessages.sell());
+        sellCommand = new SellCommand(quickSellMenu, commandMessages.sell(), quickSellEnabled);
+
         PluginManager pluginManager = plugin.getServer().getPluginManager();
         registerListener(pluginManager, shopMenu);
+        registerListener(pluginManager, quickSellMenu);
         registerCommand("shop", shopCommand);
         registerCommand("sellhand", sellHandCommand);
         registerCommand("sellinventory", sellInventoryCommand);
+        registerCommand("sell", sellCommand);
         registerCommand("price", priceCommand);
         registerCommand("pricingadmin", new com.skyblockexp.ezshops.shop.command.PricingAdminCommand(pricingManager, commandMessages.pricingAdmin()));
     }
@@ -140,6 +150,7 @@ public final class CoreShopComponent implements PluginComponent {
         }
 
         unregisterListener(shopMenu);
+        unregisterListener(quickSellMenu);
         if (plugin != null) {
             ServicesManager servicesManager = plugin.getServer().getServicesManager();
             if (shopPriceService != null) {
@@ -157,6 +168,8 @@ public final class CoreShopComponent implements PluginComponent {
         shopCommand = null;
         sellHandCommand = null;
         sellInventoryCommand = null;
+        sellCommand = null;
+        quickSellMenu = null;
         priceCommand = null;
         shopMenu = null;
         transactionService = null;

--- a/src/main/java/com/skyblockexp/ezshops/config/ShopMessageConfiguration.java
+++ b/src/main/java/com/skyblockexp/ezshops/config/ShopMessageConfiguration.java
@@ -233,6 +233,7 @@ public final class ShopMessageConfiguration {
         private final ShopCommandMessages shop = new ShopCommandMessages();
         private final SellHandCommandMessages sellHand = new SellHandCommandMessages();
         private final SellInventoryCommandMessages sellInventory = new SellInventoryCommandMessages();
+        private final SellCommandMessages sell = new SellCommandMessages();
         private final PriceCommandMessages price = new PriceCommandMessages();
         private final SignShopScanCommandMessages signShopScan = new SignShopScanCommandMessages();
         private final StockAdminCommandMessages stockAdmin = new StockAdminCommandMessages();
@@ -249,6 +250,10 @@ public final class ShopMessageConfiguration {
 
         public SellInventoryCommandMessages sellInventory() {
             return sellInventory;
+        }
+
+        public SellCommandMessages sell() {
+            return sell;
         }
 
         public PriceCommandMessages price() {
@@ -445,6 +450,34 @@ public final class ShopMessageConfiguration {
 
             public String notInRotation() {
                 return string("commands.sell-inventory.not-in-rotation", "&cNo sellable items are available in the current shop rotation.");
+            }
+        }
+
+        public final class SellCommandMessages {
+
+            public String playersOnly() {
+                return string("commands.sell.players-only", "&cOnly players can use the sell command.");
+            }
+
+            public String guiDisabled() {
+                return string("commands.sell.gui-disabled", "&cThe quick sell GUI is disabled on this server.");
+            }
+
+            public String guiTitle() {
+                return string("commands.sell.gui-title", "&8Quick Sell");
+            }
+
+            public String unsellableItem() {
+                return string("commands.sell.unsellable-item", "&cThat item cannot be sold in the shop.");
+            }
+
+            public String nothingToSell() {
+                return string("commands.sell.nothing-to-sell", "&cNo items to sell.");
+            }
+
+            public String soldSummary(String total) {
+                return format(string("commands.sell.sold-summary", "&aSold items for &6{total}&a."),
+                        Map.of("{total}", total == null ? "0" : total));
             }
         }
 

--- a/src/main/java/com/skyblockexp/ezshops/gui/quicksell/QuickSellMenu.java
+++ b/src/main/java/com/skyblockexp/ezshops/gui/quicksell/QuickSellMenu.java
@@ -50,13 +50,23 @@ public class QuickSellMenu implements Listener {
     private final ShopPricingManager pricingManager;
     private final ShopTransactionService transactionService;
     private final ShopMessageConfiguration.CommandMessages.SellCommandMessages messages;
+    /** Bukkit sound key to play on confirm, or {@code null} / empty to disable. */
+    private final String confirmSound;
+    private final float confirmSoundVolume;
+    private final float confirmSoundPitch;
 
     public QuickSellMenu(ShopPricingManager pricingManager,
             ShopTransactionService transactionService,
-            ShopMessageConfiguration.CommandMessages.SellCommandMessages messages) {
+            ShopMessageConfiguration.CommandMessages.SellCommandMessages messages,
+            String confirmSound,
+            float confirmSoundVolume,
+            float confirmSoundPitch) {
         this.pricingManager = pricingManager;
         this.transactionService = transactionService;
         this.messages = messages;
+        this.confirmSound = confirmSound;
+        this.confirmSoundVolume = confirmSoundVolume;
+        this.confirmSoundPitch = confirmSoundPitch;
     }
 
     /**
@@ -375,6 +385,10 @@ public class QuickSellMenu implements Listener {
 
         player.sendMessage(ChatColor.translateAlternateColorCodes('&',
                 messages.soldSummary(transactionService.formatCurrency(total))));
+
+        if (confirmSound != null && !confirmSound.isEmpty()) {
+            player.playSound(player.getLocation(), confirmSound, confirmSoundVolume, confirmSoundPitch);
+        }
     }
 
     /**

--- a/src/main/java/com/skyblockexp/ezshops/gui/quicksell/QuickSellMenu.java
+++ b/src/main/java/com/skyblockexp/ezshops/gui/quicksell/QuickSellMenu.java
@@ -1,0 +1,488 @@
+package com.skyblockexp.ezshops.gui.quicksell;
+
+import com.skyblockexp.ezshops.config.ShopMessageConfiguration;
+import com.skyblockexp.ezshops.gui.shop.ShopTransactionType;
+import com.skyblockexp.ezshops.shop.ShopPricingManager;
+import com.skyblockexp.ezshops.shop.ShopPrice;
+import com.skyblockexp.ezshops.shop.ShopTransactionResult;
+import com.skyblockexp.ezshops.shop.ShopTransactionService;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.ClickType;
+import org.bukkit.event.inventory.InventoryAction;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryCloseEvent;
+import org.bukkit.event.inventory.InventoryDragEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Quick Sell GUI — players drag items into a 36-slot area, see a live estimated
+ * sell total, and confirm the sale with a single button click.
+ *
+ * <p>Layout (45 slots, 5 rows):
+ * <pre>
+ *  Rows 1-4  (slots  0-35): item drop area
+ *  Row 5     (slots 36-44): control bar
+ *    36 = Cancel (BARRIER)
+ *    37,38,39,41,42,43 = Gray filler
+ *    40 = Price display (GOLD_INGOT)
+ *    44 = Confirm (LIME_STAINED_GLASS_PANE)
+ * </pre>
+ */
+public class QuickSellMenu implements Listener {
+
+    private static final int GUI_SIZE = 45;
+    private static final int ITEM_SLOT_COUNT = 36; // 0-35
+    private static final int SLOT_CANCEL = 36;
+    private static final int SLOT_PRICE = 40;
+    private static final int SLOT_CONFIRM = 44;
+
+    private final ShopPricingManager pricingManager;
+    private final ShopTransactionService transactionService;
+    private final ShopMessageConfiguration.CommandMessages.SellCommandMessages messages;
+
+    public QuickSellMenu(ShopPricingManager pricingManager,
+            ShopTransactionService transactionService,
+            ShopMessageConfiguration.CommandMessages.SellCommandMessages messages) {
+        this.pricingManager = pricingManager;
+        this.transactionService = transactionService;
+        this.messages = messages;
+    }
+
+    /**
+     * Opens the Quick Sell GUI for {@code player}.
+     */
+    public void open(Player player) {
+        QuickSellMenuHolder holder = new QuickSellMenuHolder(player.getUniqueId());
+        Inventory inv = Bukkit.createInventory(holder, GUI_SIZE,
+                ChatColor.translateAlternateColorCodes('&', messages.guiTitle()));
+        holder.setInventory(inv);
+        populateControls(inv, 0.0, player);
+        player.openInventory(inv);
+    }
+
+    // -----------------------------------------------------------------------
+    // Event handlers
+    // -----------------------------------------------------------------------
+
+    @EventHandler(priority = EventPriority.HIGH)
+    public void onInventoryClick(InventoryClickEvent event) {
+        if (!(event.getView().getTopInventory().getHolder() instanceof QuickSellMenuHolder holder)) {
+            return;
+        }
+        if (!(event.getWhoClicked() instanceof Player player)) {
+            return;
+        }
+        if (!holder.owner().equals(player.getUniqueId())) {
+            return;
+        }
+
+        // Always cancel — we handle inventory manipulation manually
+        event.setCancelled(true);
+
+        Inventory topInv = event.getView().getTopInventory();
+        int rawSlot = event.getRawSlot();
+        InventoryAction action = event.getAction();
+
+        // ----- Control row -----
+        if (rawSlot == SLOT_CANCEL) {
+            player.closeInventory(); // onInventoryClose returns items
+            return;
+        }
+        if (rawSlot == SLOT_CONFIRM) {
+            handleConfirm(player, topInv);
+            player.closeInventory();
+            return;
+        }
+        if (rawSlot > ITEM_SLOT_COUNT - 1 && rawSlot < GUI_SIZE) {
+            // Other filler slots in the control row — do nothing
+            return;
+        }
+
+        // ----- Item area (slots 0-35) -----
+        if (rawSlot >= 0 && rawSlot < ITEM_SLOT_COUNT) {
+            handleItemAreaClick(event, player, topInv, rawSlot, action);
+            return;
+        }
+
+        // ----- Player inventory area (rawSlot >= GUI_SIZE) -----
+        if (rawSlot >= GUI_SIZE) {
+            // Shift-click from player inventory into the GUI
+            if (action == InventoryAction.MOVE_TO_OTHER_INVENTORY) {
+                ItemStack clicked = event.getCurrentItem();
+                if (clicked == null || clicked.getType() == Material.AIR) {
+                    return;
+                }
+                if (!isSellable(clicked.getType())) {
+                    player.sendMessage(ChatColor.translateAlternateColorCodes('&', messages.unsellableItem()));
+                    return;
+                }
+                // Find first empty slot in item area
+                int emptySlot = findEmptyItemSlot(topInv);
+                if (emptySlot == -1) {
+                    // GUI full — leave item in player inventory
+                    return;
+                }
+                topInv.setItem(emptySlot, clicked.clone());
+                event.setCurrentItem(null);
+                refreshPriceDisplay(topInv, player);
+            }
+            // All other actions in player inventory are harmless (already cancelled)
+        }
+    }
+
+    @EventHandler(priority = EventPriority.HIGH)
+    public void onInventoryDrag(InventoryDragEvent event) {
+        if (!(event.getView().getTopInventory().getHolder() instanceof QuickSellMenuHolder holder)) {
+            return;
+        }
+        if (!(event.getWhoClicked() instanceof Player player)) {
+            return;
+        }
+        if (!holder.owner().equals(player.getUniqueId())) {
+            return;
+        }
+
+        Inventory topInv = event.getView().getTopInventory();
+        boolean touchesControlRow = event.getRawSlots().stream()
+                .anyMatch(s -> s >= ITEM_SLOT_COUNT && s < GUI_SIZE);
+        if (touchesControlRow) {
+            event.setCancelled(true);
+            return;
+        }
+
+        boolean touchesItemArea = event.getRawSlots().stream().anyMatch(s -> s < ITEM_SLOT_COUNT);
+        if (!touchesItemArea) {
+            return;
+        }
+
+        ItemStack dragged = event.getOldCursor();
+        if (dragged == null || dragged.getType() == Material.AIR) {
+            return;
+        }
+        if (!isSellable(dragged.getType())) {
+            event.setCancelled(true);
+            player.sendMessage(ChatColor.translateAlternateColorCodes('&', messages.unsellableItem()));
+            return;
+        }
+
+        // Allow the drag; schedule a price refresh for the next tick
+        Bukkit.getScheduler().runTask(
+                Bukkit.getPluginManager().getPlugin("EzShops"),
+                () -> refreshPriceDisplay(topInv, player));
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onInventoryClose(InventoryCloseEvent event) {
+        if (!(event.getInventory().getHolder() instanceof QuickSellMenuHolder holder)) {
+            return;
+        }
+        if (!(event.getPlayer() instanceof Player player)) {
+            return;
+        }
+        if (!holder.owner().equals(player.getUniqueId())) {
+            return;
+        }
+
+        // Return all items in the item area to the player
+        Inventory inv = event.getInventory();
+        for (int slot = 0; slot < ITEM_SLOT_COUNT; slot++) {
+            ItemStack item = inv.getItem(slot);
+            if (item != null && item.getType() != Material.AIR) {
+                inv.setItem(slot, null);
+                giveOrDrop(player, item);
+            }
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Internal helpers
+    // -----------------------------------------------------------------------
+
+    /**
+     * Handles a click inside the item drop area (slots 0-35).
+     */
+    private void handleItemAreaClick(InventoryClickEvent event, Player player,
+            Inventory topInv, int rawSlot, InventoryAction action) {
+
+        ItemStack cursor = player.getItemOnCursor();
+        ItemStack slotItem = topInv.getItem(rawSlot);
+        boolean cursorHasItem = cursor != null && cursor.getType() != Material.AIR;
+        boolean slotHasItem = slotItem != null && slotItem.getType() != Material.AIR;
+
+        switch (action) {
+            case PLACE_ALL, PLACE_ONE, PLACE_SOME, SWAP_WITH_CURSOR -> {
+                if (!cursorHasItem) return;
+                if (!isSellable(cursor.getType())) {
+                    player.sendMessage(ChatColor.translateAlternateColorCodes('&', messages.unsellableItem()));
+                    return;
+                }
+                // Let the server handle the actual placement by un-cancelling would be complex.
+                // We manually replicate the placement instead.
+                if (action == InventoryAction.PLACE_ALL) {
+                    if (!slotHasItem) {
+                        topInv.setItem(rawSlot, cursor.clone());
+                        player.setItemOnCursor(null);
+                    } else if (slotItem.isSimilar(cursor)) {
+                        // Stack onto existing
+                        int maxStack = slotItem.getMaxStackSize();
+                        int combined = slotItem.getAmount() + cursor.getAmount();
+                        if (combined <= maxStack) {
+                            slotItem.setAmount(combined);
+                            player.setItemOnCursor(null);
+                        } else {
+                            cursor.setAmount(combined - maxStack);
+                            slotItem.setAmount(maxStack);
+                        }
+                        topInv.setItem(rawSlot, slotItem);
+                    } else {
+                        // Swap
+                        topInv.setItem(rawSlot, cursor.clone());
+                        player.setItemOnCursor(slotItem.clone());
+                    }
+                } else if (action == InventoryAction.PLACE_ONE) {
+                    if (!slotHasItem) {
+                        ItemStack single = cursor.clone();
+                        single.setAmount(1);
+                        topInv.setItem(rawSlot, single);
+                        if (cursor.getAmount() <= 1) {
+                            player.setItemOnCursor(null);
+                        } else {
+                            cursor.setAmount(cursor.getAmount() - 1);
+                        }
+                    } else if (slotItem.isSimilar(cursor) && slotItem.getAmount() < slotItem.getMaxStackSize()) {
+                        slotItem.setAmount(slotItem.getAmount() + 1);
+                        topInv.setItem(rawSlot, slotItem);
+                        if (cursor.getAmount() <= 1) {
+                            player.setItemOnCursor(null);
+                        } else {
+                            cursor.setAmount(cursor.getAmount() - 1);
+                        }
+                    }
+                } else if (action == InventoryAction.SWAP_WITH_CURSOR) {
+                    if (slotHasItem) {
+                        topInv.setItem(rawSlot, cursor.clone());
+                        player.setItemOnCursor(slotItem.clone());
+                    }
+                }
+                refreshPriceDisplay(topInv, player);
+            }
+            case PICKUP_ALL, PICKUP_ONE, PICKUP_HALF, PICKUP_SOME -> {
+                if (!slotHasItem) return;
+                // Move item back to cursor / player inventory
+                if (action == InventoryAction.PICKUP_ALL) {
+                    player.setItemOnCursor(slotItem.clone());
+                    topInv.setItem(rawSlot, null);
+                } else if (action == InventoryAction.PICKUP_HALF || action == InventoryAction.PICKUP_SOME) {
+                    int half = (int) Math.ceil(slotItem.getAmount() / 2.0);
+                    int remaining = slotItem.getAmount() - half;
+                    ItemStack taken = slotItem.clone();
+                    taken.setAmount(half);
+                    player.setItemOnCursor(taken);
+                    if (remaining > 0) {
+                        slotItem.setAmount(remaining);
+                        topInv.setItem(rawSlot, slotItem);
+                    } else {
+                        topInv.setItem(rawSlot, null);
+                    }
+                } else if (action == InventoryAction.PICKUP_ONE) {
+                    ItemStack one = slotItem.clone();
+                    one.setAmount(1);
+                    player.setItemOnCursor(one);
+                    if (slotItem.getAmount() <= 1) {
+                        topInv.setItem(rawSlot, null);
+                    } else {
+                        slotItem.setAmount(slotItem.getAmount() - 1);
+                        topInv.setItem(rawSlot, slotItem);
+                    }
+                }
+                refreshPriceDisplay(topInv, player);
+            }
+            case DROP_ONE_SLOT, DROP_ALL_SLOT -> {
+                if (!slotHasItem) return;
+                int dropAmount = action == InventoryAction.DROP_ONE_SLOT ? 1 : slotItem.getAmount();
+                ItemStack drop = slotItem.clone();
+                drop.setAmount(dropAmount);
+                player.getWorld().dropItemNaturally(player.getLocation(), drop);
+                if (dropAmount >= slotItem.getAmount()) {
+                    topInv.setItem(rawSlot, null);
+                } else {
+                    slotItem.setAmount(slotItem.getAmount() - dropAmount);
+                    topInv.setItem(rawSlot, slotItem);
+                }
+                refreshPriceDisplay(topInv, player);
+            }
+            case COLLECT_TO_CURSOR -> {
+                // Pull matching items from the item area into cursor
+                ItemStack cur = player.getItemOnCursor();
+                if (cur == null || cur.getType() == Material.AIR) return;
+                int needed = cur.getMaxStackSize() - cur.getAmount();
+                for (int s = 0; s < ITEM_SLOT_COUNT && needed > 0; s++) {
+                    ItemStack candidate = topInv.getItem(s);
+                    if (candidate == null || !candidate.isSimilar(cur)) continue;
+                    int take = Math.min(candidate.getAmount(), needed);
+                    cur.setAmount(cur.getAmount() + take);
+                    needed -= take;
+                    if (take >= candidate.getAmount()) {
+                        topInv.setItem(s, null);
+                    } else {
+                        candidate.setAmount(candidate.getAmount() - take);
+                        topInv.setItem(s, candidate);
+                    }
+                }
+                refreshPriceDisplay(topInv, player);
+            }
+            default -> { /* ignore hotbar number, clone, etc. */ }
+        }
+    }
+
+    /**
+     * Sells all items currently in the item area and closes the GUI.
+     */
+    private void handleConfirm(Player player, Inventory topInv) {
+        double total = 0.0;
+        boolean soldAnything = false;
+
+        for (int slot = 0; slot < ITEM_SLOT_COUNT; slot++) {
+            ItemStack item = topInv.getItem(slot);
+            if (item == null || item.getType() == Material.AIR) continue;
+
+            ShopTransactionResult result = transactionService.sell(player, item.getType(), item.getAmount());
+            if (result.success()) {
+                topInv.setItem(slot, null);
+                // Accumulate the sell value from the pricing manager for the summary
+                total += pricingManager.estimateBulkTotal(
+                        item.getType().name(), item.getAmount(), ShopTransactionType.SELL);
+                soldAnything = true;
+            }
+            // Failed items remain in the slot; onInventoryClose will return them
+        }
+
+        if (!soldAnything) {
+            player.sendMessage(ChatColor.translateAlternateColorCodes('&', messages.nothingToSell()));
+            return;
+        }
+
+        player.sendMessage(ChatColor.translateAlternateColorCodes('&',
+                messages.soldSummary(transactionService.formatCurrency(total))));
+    }
+
+    /**
+     * Recalculates the estimated sell total and updates the price display slot.
+     */
+    private void refreshPriceDisplay(Inventory topInv, Player player) {
+        double total = 0.0;
+        for (int slot = 0; slot < ITEM_SLOT_COUNT; slot++) {
+            ItemStack item = topInv.getItem(slot);
+            if (item == null || item.getType() == Material.AIR) continue;
+            total += pricingManager.estimateBulkTotal(
+                    item.getType().name(), item.getAmount(), ShopTransactionType.SELL);
+        }
+        updatePriceItem(topInv, total, player);
+    }
+
+    /**
+     * Builds and places the control row into the given inventory.
+     */
+    private void populateControls(Inventory inv, double currentTotal, Player player) {
+        // Gray glass filler
+        ItemStack filler = buildNamedItem(Material.GRAY_STAINED_GLASS_PANE, " ");
+        for (int slot = ITEM_SLOT_COUNT; slot < GUI_SIZE; slot++) {
+            inv.setItem(slot, filler);
+        }
+
+        // Cancel button
+        ItemStack cancel = buildNamedItem(Material.BARRIER,
+                ChatColor.RED + "Cancel",
+                ChatColor.GRAY + "Return all items to your inventory");
+        inv.setItem(SLOT_CANCEL, cancel);
+
+        // Price display
+        updatePriceItem(inv, currentTotal, player);
+
+        // Confirm button
+        ItemStack confirm = buildNamedItem(Material.LIME_STAINED_GLASS_PANE,
+                ChatColor.GREEN + "Confirm Sale",
+                ChatColor.GRAY + "Click to sell all items above");
+        inv.setItem(SLOT_CONFIRM, confirm);
+    }
+
+    /**
+     * Rebuilds the price display item at {@value #SLOT_PRICE}.
+     */
+    private void updatePriceItem(Inventory inv, double total, Player player) {
+        String formatted = transactionService.formatCurrency(total);
+        ItemStack priceItem = buildNamedItem(Material.GOLD_INGOT,
+                ChatColor.GOLD + "Estimated Total: " + ChatColor.YELLOW + "~" + formatted,
+                ChatColor.GRAY + "Place items above to sell them",
+                ChatColor.GRAY + "The actual payout may differ slightly");
+        inv.setItem(SLOT_PRICE, priceItem);
+    }
+
+    /**
+     * Returns {@code true} if the material has a configured sell price and is
+     * currently available (visible / not rotation-hidden).
+     */
+    private boolean isSellable(Material material) {
+        if (material == null || material == Material.AIR) return false;
+        // Rotation check: if the item is part of a rotation but not currently visible, reject it
+        if (!pricingManager.isVisibleInMenu(material) && pricingManager.isPartOfRotation(material)) {
+            return false;
+        }
+        return pricingManager.getPrice(material)
+                .map(ShopPrice::canSell)
+                .orElse(false);
+    }
+
+    /**
+     * Finds the first empty slot in the item area (0-35), or -1 if full.
+     */
+    private int findEmptyItemSlot(Inventory inv) {
+        for (int slot = 0; slot < ITEM_SLOT_COUNT; slot++) {
+            ItemStack item = inv.getItem(slot);
+            if (item == null || item.getType() == Material.AIR) return slot;
+        }
+        return -1;
+    }
+
+    /**
+     * Gives {@code item} to the player's inventory, dropping overflow at their feet.
+     */
+    private void giveOrDrop(Player player, ItemStack item) {
+        var leftovers = player.getInventory().addItem(item);
+        for (ItemStack overflow : leftovers.values()) {
+            player.getWorld().dropItemNaturally(player.getLocation(), overflow);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Item builder helpers
+    // -----------------------------------------------------------------------
+
+    private static ItemStack buildNamedItem(Material material, String name, String... lore) {
+        ItemStack item = new ItemStack(material);
+        ItemMeta meta = item.getItemMeta();
+        if (meta != null) {
+            meta.setDisplayName(name);
+            if (lore.length > 0) {
+                List<String> loreList = new ArrayList<>(lore.length);
+                for (String line : lore) {
+                    loreList.add(line);
+                }
+                meta.setLore(loreList);
+            }
+            item.setItemMeta(meta);
+        }
+        return item;
+    }
+}

--- a/src/main/java/com/skyblockexp/ezshops/gui/quicksell/QuickSellMenuHolder.java
+++ b/src/main/java/com/skyblockexp/ezshops/gui/quicksell/QuickSellMenuHolder.java
@@ -1,0 +1,14 @@
+package com.skyblockexp.ezshops.gui.quicksell;
+
+import com.skyblockexp.ezshops.gui.shop.AbstractShopMenuHolder;
+import java.util.UUID;
+
+/**
+ * Inventory holder marker for the Quick Sell GUI.
+ */
+public class QuickSellMenuHolder extends AbstractShopMenuHolder {
+
+    public QuickSellMenuHolder(UUID owner) {
+        super(owner);
+    }
+}

--- a/src/main/java/com/skyblockexp/ezshops/shop/command/SellCommand.java
+++ b/src/main/java/com/skyblockexp/ezshops/shop/command/SellCommand.java
@@ -1,0 +1,42 @@
+package com.skyblockexp.ezshops.shop.command;
+
+import com.skyblockexp.ezshops.config.ShopMessageConfiguration;
+import com.skyblockexp.ezshops.gui.quicksell.QuickSellMenu;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+/**
+ * Handles the {@code /sell} command, opening the Quick Sell GUI for the player.
+ */
+public class SellCommand implements CommandExecutor {
+
+    private final QuickSellMenu quickSellMenu;
+    private final ShopMessageConfiguration.CommandMessages.SellCommandMessages messages;
+    private final boolean enabled;
+
+    public SellCommand(QuickSellMenu quickSellMenu,
+            ShopMessageConfiguration.CommandMessages.SellCommandMessages messages,
+            boolean enabled) {
+        this.quickSellMenu = quickSellMenu;
+        this.messages = messages;
+        this.enabled = enabled;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage(messages.playersOnly());
+            return true;
+        }
+
+        if (!enabled) {
+            player.sendMessage(messages.guiDisabled());
+            return true;
+        }
+
+        quickSellMenu.open(player);
+        return true;
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -69,6 +69,13 @@ quick-sell:
   # Default: true
   enabled: true
 
+  # Sound played to the player when a sale is successfully confirmed.
+  # Set name to an empty string to disable the sound entirely.
+  confirm-sound:
+    name: "entity.experience_orb.pickup"
+    volume: 1.0
+    pitch: 1.0
+
 sell:
   # Ignore items with NBT (custom tags/metadata) during /sellhand and /sellinventory
   # When enabled, only plain items without NBT will be sold.

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -62,6 +62,13 @@ categories:
   # a single paginated list instead of disabling the menu entirely.
   single-list-when-disabled: false
 
+quick-sell:
+  # When enabled, /sell opens the Quick Sell GUI where players can drag items
+  # in and sell them all at once with a single Confirm click.
+  # When disabled, /sell sends a disabled message.
+  # Default: true
+  enabled: true
+
 sell:
   # Ignore items with NBT (custom tags/metadata) during /sellhand and /sellinventory
   # When enabled, only plain items without NBT will be sold.

--- a/src/main/resources/messages/messages_en.yml
+++ b/src/main/resources/messages/messages_en.yml
@@ -20,6 +20,13 @@ commands:
   sell-inventory:
     players-only: "&cOnly players can sell items."
     not-in-rotation: "&cNo sellable items are available in the current shop rotation."
+  sell:
+    players-only: "&cOnly players can use the sell command."
+    gui-disabled: "&cThe quick sell GUI is disabled on this server."
+    gui-title: "&8Quick Sell"
+    unsellable-item: "&cThat item cannot be sold in the shop."
+    nothing-to-sell: "&cNo items to sell."
+    sold-summary: "&aSold items for &6{total}&a."
   price:
     usage: "&eUsage: /{label} <item>"
     unknown-item: "&cUnknown item: {item}"

--- a/src/main/resources/messages/messages_es.yml
+++ b/src/main/resources/messages/messages_es.yml
@@ -20,6 +20,13 @@ commands:
   sell-inventory:
     players-only: "&cSolo los jugadores pueden vender artículos."
     not-in-rotation: "&cNo hay artículos vendibles disponibles en la rotación actual."
+  sell:
+    players-only: "&cSolo los jugadores pueden usar el comando de venta."
+    gui-disabled: "&cLa GUI de venta rápida está deshabilitada en este servidor."
+    gui-title: "&8Venta Rápida"
+    unsellable-item: "&cEse artículo no se puede vender en la tienda."
+    nothing-to-sell: "&cNo hay artículos para vender."
+    sold-summary: "&aArtículos vendidos por &6{total}&a."
   price:
     usage: "&eUso: /{label} <artículo>"
     unknown-item: "&cArtículo desconocido: {item}"

--- a/src/main/resources/messages/messages_nl.yml
+++ b/src/main/resources/messages/messages_nl.yml
@@ -17,6 +17,13 @@ commands:
   sell-inventory:
     players-only: "&cAlleen spelers kunnen items verkopen."
     not-in-rotation: "&cEr zijn geen verkoopbare items beschikbaar in de huidige winkelrotatie."
+  sell:
+    players-only: "&cAlleen spelers kunnen het verkoop-commando gebruiken."
+    gui-disabled: "&cDe snelverkoop-GUI is uitgeschakeld op deze server."
+    gui-title: "&8Snel Verkopen"
+    unsellable-item: "&cDat item kan niet worden verkocht in de winkel."
+    nothing-to-sell: "&cGeen items om te verkopen."
+    sold-summary: "&aItems verkocht voor &6{total}&a."
   price:
     usage: "&eGebruik: /{label} <item>"
     unknown-item: "&cOnbekend item: {item}"

--- a/src/main/resources/messages/messages_zh.yml
+++ b/src/main/resources/messages/messages_zh.yml
@@ -17,6 +17,13 @@ commands:
   sell-inventory:
     players-only: "&c只有玩家可以出售物品。"
     not-in-rotation: "&c当前商店轮换中没有可出售的物品。"
+  sell:
+    players-only: "&c只有玩家可以使用出售指令。"
+    gui-disabled: "&c此服务器已禁用快速出售 GUI。"
+    gui-title: "&8快速出售"
+    unsellable-item: "&c该物品无法在商店中出售。"
+    nothing-to-sell: "&c没有可出售的物品。"
+    sold-summary: "&a物品已以 &6{total}&a 的价格出售。"
   price:
     usage: "&e用法：/{label} <item>"
     unknown-item: "&c未知物品：{item}"

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -11,6 +11,10 @@ commands:
     description: Access the Skyblock shop to buy or sell items.
     usage: /<command>
     permission: ezshops.shop
+  sell:
+    description: Open the quick sell GUI to sell items quickly.
+    usage: /<command>
+    permission: ezshops.shop.sell
   sellhand:
     description: Sell the item currently in your hand to the shop.
     usage: /<command>

--- a/src/test/java/com/skyblockexp/ezshops/AbstractEzShopsTest.java
+++ b/src/test/java/com/skyblockexp/ezshops/AbstractEzShopsTest.java
@@ -3,13 +3,28 @@ package com.skyblockexp.ezshops;
 import org.mockbukkit.mockbukkit.MockBukkit;
 import org.mockbukkit.mockbukkit.ServerMock;
 import net.milkbowl.vault.economy.Economy;
+import org.bukkit.plugin.InvalidDescriptionException;
+import org.bukkit.plugin.PluginDescriptionFile;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import sun.misc.Unsafe;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.util.logging.Logger;
 
 /**
  * Abstract base for MockBukkit-based tests.
  * Sets up a ServerMock and provides helpers for loading plugins and registering an Economy provider.
+ *
+ * <p>Uses {@link Unsafe#allocateInstance} to bypass the {@link JavaPlugin} no-arg constructor,
+ * which on Java 21+ throws {@link IllegalStateException} unless the class is loaded by a
+ * {@code ConfiguredPluginClassLoader}. After allocation, {@link JavaPlugin#init} is called
+ * directly to set all required fields.</p>
  */
 public abstract class AbstractEzShopsTest {
 
@@ -28,8 +43,29 @@ public abstract class AbstractEzShopsTest {
         }
     }
 
+    /**
+     * Loads and enables a plugin, bypassing MockBukkit's broken ByteBuddy proxy-class loading.
+     *
+     * <p>Uses {@link Unsafe#allocateInstance} so the {@link JavaPlugin} constructor check is
+     * skipped, then calls {@link JavaPlugin#init} to properly initialise the instance.</p>
+     */
     protected <T extends JavaPlugin> T loadPlugin(Class<T> pluginClass) {
-        return MockBukkit.load(pluginClass);
+        try {
+            PluginDescriptionFile description;
+            try (InputStream is = pluginClass.getResourceAsStream("/plugin.yml")) {
+                description = new PluginDescriptionFile(is);
+            }
+            File dataFolder = Files.createTempDirectory("test-plugin-" + description.getName()).toFile();
+            @SuppressWarnings("unchecked")
+            T plugin = (T) getUnsafe().allocateInstance(pluginClass);
+            plugin.init(server, description, dataFolder, new File(""),
+                    pluginClass.getClassLoader(), description, Logger.getLogger(description.getName()));
+            server.getPluginManager().registerLoadedPlugin(plugin);
+            server.getPluginManager().enablePlugin(plugin);
+            return plugin;
+        } catch (InvalidDescriptionException | IOException | InstantiationException e) {
+            throw new RuntimeException("Failed to load plugin " + pluginClass.getSimpleName(), e);
+        }
     }
 
     /**
@@ -37,7 +73,30 @@ public abstract class AbstractEzShopsTest {
      */
     protected void loadProviderPlugin(Economy econ) {
         TestProviderPlugin.econToRegister = econ;
-        MockBukkit.load(TestProviderPlugin.class);
+        try {
+            PluginDescriptionFile description = new PluginDescriptionFile(
+                    "TestEconomyProvider", "1.0", TestProviderPlugin.class.getName());
+            File dataFolder = Files.createTempDirectory("test-plugin-provider").toFile();
+            @SuppressWarnings("unchecked")
+            TestProviderPlugin plugin = (TestProviderPlugin) getUnsafe().allocateInstance(TestProviderPlugin.class);
+            plugin.init(server, description, dataFolder, new File(""),
+                    TestProviderPlugin.class.getClassLoader(), description,
+                    Logger.getLogger("TestEconomyProvider"));
+            server.getPluginManager().registerLoadedPlugin(plugin);
+            server.getPluginManager().enablePlugin(plugin);
+        } catch (IOException | InstantiationException e) {
+            throw new RuntimeException("Failed to load provider plugin", e);
+        }
+    }
+
+    private static Unsafe getUnsafe() {
+        try {
+            Field field = Unsafe.class.getDeclaredField("theUnsafe");
+            field.setAccessible(true);
+            return (Unsafe) field.get(null);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException("Cannot access Unsafe", e);
+        }
     }
 
     public static class TestProviderPlugin extends JavaPlugin {

--- a/src/test/java/com/skyblockexp/ezshops/gui/StockGuiFeatureTest.java
+++ b/src/test/java/com/skyblockexp/ezshops/gui/StockGuiFeatureTest.java
@@ -19,7 +19,8 @@ public class StockGuiFeatureTest extends AbstractEzShopsTest {
         assertNotNull(stock, "StockComponent should be initialized when stock is enabled");
 
         org.bukkit.entity.Player player = server.addPlayer("stock-player");
-        // grant permission required by the command
+        // grant permission required by the command and GUI
+        player.addAttachment(plugin, "ezshops.stock.view", true);
         player.addAttachment(plugin, "ezshops.stock.overview", true);
         // dispatch the stock overview command which should open the GUI
         boolean dispatched = server.dispatchCommand(player, "stock overview");

--- a/src/test/java/com/skyblockexp/ezshops/gui/StockGuiInteractionTest.java
+++ b/src/test/java/com/skyblockexp/ezshops/gui/StockGuiInteractionTest.java
@@ -15,6 +15,7 @@ public class StockGuiInteractionTest extends AbstractEzShopsTest {
         assertNotNull(plugin);
 
         org.bukkit.entity.Player player = server.addPlayer("stock-interact");
+        player.addAttachment(plugin, "ezshops.stock.view", true);
         player.addAttachment(plugin, "ezshops.stock.overview", true);
 
         // open stock overview via command

--- a/src/test/java/com/skyblockexp/ezshops/shop/ShopCommandCategoryTest.java
+++ b/src/test/java/com/skyblockexp/ezshops/shop/ShopCommandCategoryTest.java
@@ -31,6 +31,7 @@ public class ShopCommandCategoryTest extends AbstractEzShopsTest {
         String display = MessageUtil.stripColors(MessageUtil.translateColors(category.displayName()));
 
         org.bukkit.entity.Player player = server.addPlayer("cmd-player");
+        player.addAttachment(plugin, "ezshops.shop", true);
 
         boolean dispatched = server.dispatchCommand(player, "shop " + display);
         assertTrue(dispatched, "Command should be dispatched");
@@ -66,6 +67,7 @@ public class ShopCommandCategoryTest extends AbstractEzShopsTest {
         String display = MessageUtil.stripColors(MessageUtil.translateColors(category.displayName()));
 
         org.bukkit.entity.Player player = server.addPlayer("cmd-player-2");
+        player.addAttachment(plugin, "ezshops.shop", true);
 
         boolean dispatched = server.dispatchCommand(player, "shop " + display);
         assertTrue(dispatched, "Command should be dispatched");

--- a/src/test/java/com/skyblockexp/ezshops/shop/ShopTemplateFeatureTest.java
+++ b/src/test/java/com/skyblockexp/ezshops/shop/ShopTemplateFeatureTest.java
@@ -41,6 +41,7 @@ public class ShopTemplateFeatureTest extends AbstractEzShopsTest {
 
         // Create a player and grant import permission
         org.bukkit.entity.Player player = server.addPlayer("importer");
+        player.addAttachment(plugin, "ezshops.shop", true);
         player.addAttachment(plugin, "ezshops.import", true);
 
         // Dispatch the import command


### PR DESCRIPTION
## Add a new `/sell` command that opens a 45-slot Quick Sell inventory GUI.

- Slots 0-35 (rows 1-4) are the item drop area
- Control row (row 5): Cancel (`BARRIER`, slot 36), live price display
  (`GOLD_INGOT`, slot 40), Confirm (`LIME_STAINED_GLASS_PANE`, slot 44)
- Unsellable/rotation-hidden items are blocked at placement with a chat message
- Live estimated sell total updates after every click or drag event
- Confirming sells all items via `ShopTransactionService` and sends a summary
- Closing without confirming returns all items to the player's inventory
- `quick-sell.enabled` config flag to disable the feature server-side
- Full i18n across all four language files (en/nl/es/zh)
- Permission: `ezshops.shop.sell`