### PR TITLE
config: remove sell portal from default shop

### DIFF
--- a/src/main/resources/messages/messages_en.yml
+++ b/src/main/resources/messages/messages_en.yml
@@ -400,10 +400,6 @@ shop:
       icon-lore: "&7Automation components and wiring."
       menu:
         title: "&cRedstone & Utility"
-      sell-portal-display-name: "&6Sell Portal"
-      sell-portal-lore-1: "&7Automatically sells items that touch the portal."
-      sell-portal-lore-2: "&7Price: &a{buy}"
-      sell-portal-lore-3: "&7Only items with a shop sell price are converted."
     spawners:
       name: "&6Mob Spawners"
       icon-display-name: "&6Mob Spawners"

--- a/src/main/resources/messages/messages_es.yml
+++ b/src/main/resources/messages/messages_es.yml
@@ -401,10 +401,6 @@ shop:
       icon-lore: "&7Componentes de automatización y cableado."
       menu:
         title: "&cRedstone y utilidad"
-      sell-portal-display-name: "&6Portal de venta"
-      sell-portal-lore-1: "&7Vende automáticamente los artículos que tocan el portal."
-      sell-portal-lore-2: "&7Precio: &a{buy}"
-      sell-portal-lore-3: "&7Solo los artículos con precio de venta en la tienda se convierten."
     spawners:
       name: "&6Generadores de mobs"
       icon-display-name: "&6Generadores de mobs"

--- a/src/main/resources/messages/messages_nl.yml
+++ b/src/main/resources/messages/messages_nl.yml
@@ -332,10 +332,6 @@ shop:
       icon-lore: "&7Automation components and wiring."
       menu:
         title: "&cRedstone & Utility"
-      sell-portal-display-name: "&6Sell Portal"
-      sell-portal-lore-1: "&7Automatically sells items that touch the portal."
-      sell-portal-lore-2: "&7Price: &a{buy}"
-      sell-portal-lore-3: "&7Only items with a shop sell price are converted."
     spawners:
       name: "&6Mob Spawners"
       icon-display-name: "&6Mob Spawners"

--- a/src/main/resources/messages/messages_zh.yml
+++ b/src/main/resources/messages/messages_zh.yml
@@ -332,10 +332,6 @@ shop:
       icon-lore: "&7Automation components and wiring."
       menu:
         title: "&cRedstone & Utility"
-      sell-portal-display-name: "&6Sell Portal"
-      sell-portal-lore-1: "&7Automatically sells items that touch the portal."
-      sell-portal-lore-2: "&7Price: &a{buy}"
-      sell-portal-lore-3: "&7Only items with a shop sell price are converted."
     spawners:
       name: "&6Mob Spawners"
       icon-display-name: "&6Mob Spawners"

--- a/src/main/resources/shop/categories/redstone.yml
+++ b/src/main/resources/shop/categories/redstone.yml
@@ -344,16 +344,3 @@ categories:
         - "{translate:shop.common.shift-click-line}"
         buy: 90.0
         sell: 32.0
-      sell_portal:
-        material: END_PORTAL_FRAME
-        slot: 43
-        amount: 1
-        bulk-amount: 1
-        icon-amount: 1
-        display-name: "{translate:shop.categories.redstone.sell-portal-display-name}"
-        lore:
-        - "{translate:shop.categories.redstone.sell-portal-lore-1}"
-        - "{translate:shop.categories.redstone.sell-portal-lore-2}"
-        - "{translate:shop.categories.redstone.sell-portal-lore-3}"
-        buy: 500000.0
-        sell: -1


### PR DESCRIPTION
Remove the sell_portal item from the redstone category and its corresponding display-name / lore translation keys from all four locale files (en, es, nl, zh).