### PR TITLE
Remove getMinecraftVersion() check for PDC support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.skyblockexp</groupId>
     <artifactId>ezshops</artifactId>
-    <version>2.4.0</version>
+    <version>2.4.1</version>
     <name>EzShops Plugin</name>
     <description>Standalone plugin providing the Skyblock shop command and sign shops.</description>
     <packaging>jar</packaging>

--- a/src/main/java/com/skyblockexp/ezshops/common/CompatibilityUtil.java
+++ b/src/main/java/com/skyblockexp/ezshops/common/CompatibilityUtil.java
@@ -140,7 +140,7 @@ public final class CompatibilityUtil {
         if (hasPersistentData == null) {
             try {
                 Class.forName("org.bukkit.persistence.PersistentDataContainer");
-                hasPersistentData = getMinecraftVersion() >= 14;
+                hasPersistentData = true;
             } catch (ClassNotFoundException e) {
                 hasPersistentData = false;
             }

--- a/src/main/java/com/skyblockexp/ezshops/gui/ShopMenu.java
+++ b/src/main/java/com/skyblockexp/ezshops/gui/ShopMenu.java
@@ -189,6 +189,7 @@ public class ShopMenu implements Listener {
 
     @EventHandler
     public void onInventoryClick(InventoryClickEvent event) {
+        boolean debugMode = plugin.getConfig().getBoolean("debug", false);
         Inventory topInventory = event.getView().getTopInventory();
         if (!(topInventory.getHolder() instanceof AbstractShopMenuHolder holder)) {
             return;
@@ -197,31 +198,44 @@ public class ShopMenu implements Listener {
         event.setCancelled(true);
 
         if (!(event.getWhoClicked() instanceof Player player)) {
+            if (debugMode) plugin.getLogger().info("[Debug] onInventoryClick: not a player");
             return;
         }
+
+        if (debugMode) plugin.getLogger().info("[Debug] onInventoryClick: holder=" + holder.getClass().getSimpleName() + " player=" + player.getName() + " slot=" + event.getRawSlot());
 
         if (!holder.owner().equals(player.getUniqueId())) {
+            if (debugMode) plugin.getLogger().info("[Debug] onInventoryClick: owner mismatch, holder.owner=" + holder.owner() + " player=" + player.getUniqueId());
             return;
         }
 
-        if (event.getClickedInventory() == null || event.getClickedInventory().getHolder() != holder) {
+        if (event.getClickedInventory() == null) {
+            if (debugMode) plugin.getLogger().info("[Debug] onInventoryClick: clickedInventory is null");
+            return;
+        }
+        if (event.getClickedInventory().getHolder() != holder) {
+            if (debugMode) plugin.getLogger().info("[Debug] onInventoryClick: clickedInventory.holder != holder; clickedHolder=" + (event.getClickedInventory().getHolder() == null ? "null" : event.getClickedInventory().getHolder().getClass().getSimpleName()));
             return;
         }
 
         ItemStack clicked = event.getCurrentItem();
         if (clicked == null || clicked.getType() == Material.AIR) {
+            if (debugMode) plugin.getLogger().info("[Debug] onInventoryClick: clicked item is null or AIR");
             return;
         }
 
         ItemMeta meta = clicked.getItemMeta();
         if (meta == null) {
+            if (debugMode) plugin.getLogger().info("[Debug] onInventoryClick: item meta is null");
             return;
         }
 
         PersistentDataContainer container = CompatibilityUtil.getPersistentDataContainer(meta);
+        if (debugMode) plugin.getLogger().info("[Debug] onInventoryClick: container=" + (container == null ? "null" : "ok") + " PDCSupport=" + CompatibilityUtil.hasPersistentDataSupport());
 
         // Dispatch configurable button actions (valid in any menu type)
         String action = CompatibilityUtil.get(container, actionKey, PersistentDataType.STRING);
+        if (debugMode) plugin.getLogger().info("[Debug] onInventoryClick: action=" + action);
         if (ShopInventoryComposer.ACTION_CLOSE.equalsIgnoreCase(action)) {
             player.closeInventory();
             return;
@@ -253,6 +267,7 @@ public class ShopMenu implements Listener {
 
         if (holder instanceof MainShopMenuHolder) {
             String categoryId = CompatibilityUtil.get(container, categoryKey, PersistentDataType.STRING);
+            if (debugMode) plugin.getLogger().info("[Debug] onInventoryClick: MainShopMenuHolder, categoryId=" + categoryId);
             if (categoryId != null) {
                 handleCategoryClick((Player) event.getWhoClicked(), categoryId);
             }

--- a/src/main/java/com/skyblockexp/ezshops/gui/ShopMenu.java
+++ b/src/main/java/com/skyblockexp/ezshops/gui/ShopMenu.java
@@ -379,7 +379,7 @@ public class ShopMenu implements Listener {
                     player.closeInventory();
                     plugin.getServer().dispatchCommand(player, commandToRun);
                 } else {
-                    openCategory(player, category);
+                    plugin.getServer().getScheduler().runTask(plugin, () -> openCategory(player, category));
                 }
                 return;
             }

--- a/src/test/java/com/skyblockexp/ezshops/gui/ShopGuiBackNavigationTest.java
+++ b/src/test/java/com/skyblockexp/ezshops/gui/ShopGuiBackNavigationTest.java
@@ -57,6 +57,9 @@ public class ShopGuiBackNavigationTest extends AbstractEzShopsTest {
         handleCategory.setAccessible(true);
         handleCategory.invoke(shopMenu, player, categoryId);
 
+        // flush the scheduled runTask so openCategory executes
+        ((org.mockbukkit.mockbukkit.scheduler.BukkitSchedulerMock) server.getScheduler()).performOneTick();
+
         // Now find back button in the category menu
         var newTop = player.getOpenInventory().getTopInventory();
         assertNotNull(newTop);

--- a/src/test/java/com/skyblockexp/ezshops/gui/ShopGuiInteractionTest.java
+++ b/src/test/java/com/skyblockexp/ezshops/gui/ShopGuiInteractionTest.java
@@ -31,12 +31,20 @@ public class ShopGuiInteractionTest extends AbstractEzShopsTest {
         org.bukkit.inventory.Inventory top = player.getOpenInventory().getTopInventory();
         assertNotNull(top);
 
-        // find first non-empty slot (a category) and simulate left-click
+        // find first CATEGORY ICON (item with shop_category PDC) and simulate left-click
         int slot = -1;
+        org.bukkit.NamespacedKey catKey = new org.bukkit.NamespacedKey(plugin, "shop_category");
         for (int i = 0; i < top.getSize(); i++) {
-            if (top.getItem(i) != null && top.getItem(i).getType() != org.bukkit.Material.AIR) { slot = i; break; }
+            org.bukkit.inventory.ItemStack it = top.getItem(i);
+            if (it == null || it.getType() == org.bukkit.Material.AIR) continue;
+            org.bukkit.inventory.meta.ItemMeta im = it.getItemMeta();
+            if (im == null) continue;
+            if (im.getPersistentDataContainer().has(catKey, org.bukkit.persistence.PersistentDataType.STRING)) {
+                slot = i;
+                break;
+            }
         }
-        assertTrue(slot >= 0, "Expected at least one category icon in main menu");
+        assertTrue(slot >= 0, "Expected at least one category icon with shop_category PDC in main menu");
 
         org.bukkit.inventory.InventoryView view = player.getOpenInventory();
         org.bukkit.event.inventory.InventoryClickEvent click = new org.bukkit.event.inventory.InventoryClickEvent(view, org.bukkit.event.inventory.InventoryType.SlotType.CONTAINER, slot, org.bukkit.event.inventory.ClickType.LEFT, org.bukkit.event.inventory.InventoryAction.PICKUP_ALL);
@@ -45,10 +53,13 @@ public class ShopGuiInteractionTest extends AbstractEzShopsTest {
         // flush the scheduled runTask so openCategory executes
         ((org.mockbukkit.mockbukkit.scheduler.BukkitSchedulerMock) server.getScheduler()).performOneTick();
 
-        // after click, top inventory should be replaced by a category or flat menu
+        // after click, top inventory should be replaced by a category menu
         org.bukkit.inventory.Inventory newTop = player.getOpenInventory().getTopInventory();
         assertNotNull(newTop);
-        // holder should be an AbstractShopMenuHolder (category/flat menu)
-        assertTrue(newTop.getHolder() instanceof com.skyblockexp.ezshops.gui.shop.AbstractShopMenuHolder);
+        // holder should be a CategoryShopMenuHolder or FlatShopMenuHolder, NOT the main menu
+        assertTrue(newTop.getHolder() instanceof com.skyblockexp.ezshops.gui.shop.CategoryShopMenuHolder
+                || newTop.getHolder() instanceof com.skyblockexp.ezshops.gui.shop.FlatShopMenuHolder,
+                "Expected CategoryShopMenuHolder or FlatShopMenuHolder but got: "
+                        + (newTop.getHolder() == null ? "null" : newTop.getHolder().getClass().getName()));
     }
 }

--- a/src/test/java/com/skyblockexp/ezshops/gui/ShopGuiInteractionTest.java
+++ b/src/test/java/com/skyblockexp/ezshops/gui/ShopGuiInteractionTest.java
@@ -42,6 +42,9 @@ public class ShopGuiInteractionTest extends AbstractEzShopsTest {
         org.bukkit.event.inventory.InventoryClickEvent click = new org.bukkit.event.inventory.InventoryClickEvent(view, org.bukkit.event.inventory.InventoryType.SlotType.CONTAINER, slot, org.bukkit.event.inventory.ClickType.LEFT, org.bukkit.event.inventory.InventoryAction.PICKUP_ALL);
         plugin.getServer().getPluginManager().callEvent(click);
 
+        // flush the scheduled runTask so openCategory executes
+        ((org.mockbukkit.mockbukkit.scheduler.BukkitSchedulerMock) server.getScheduler()).performOneTick();
+
         // after click, top inventory should be replaced by a category or flat menu
         org.bukkit.inventory.Inventory newTop = player.getOpenInventory().getTopInventory();
         assertNotNull(newTop);


### PR DESCRIPTION
- Fixed issue: Bukkit's `getMinecraftVersion() >= 14` failed because of new `26.1` version format