### PR TITLE
Folia Support

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -1,0 +1,47 @@
+name: Smoke Tests
+
+on:
+  push:
+    branches: [ main, master ]
+  workflow_dispatch:
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Cache Maven local repository
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-m2-smoke-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-m2-smoke-
+
+      - name: Build plugin
+        run: mvn -B -DskipTests package
+
+      - name: Run smoke tests
+        run: |
+          mvn -B \
+            -Dpaper.version=1.21.11-R0.1-SNAPSHOT \
+            -Dmockbukkit.artifactId=mockbukkit-v1.21 \
+            -Dmockbukkit.version=4.101.0 \
+            -Dtest=EzShopsPluginFeatureTest,PluginLifecycleFeatureTest,EzShopsAPITest \
+            test
+
+      - name: Upload jar artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: EzShops-smoke-${{ github.sha }}
+          path: target/*.jar
+          retention-days: 7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.5.1] - 2026-05-12
+
+### Added
+- **Folia support** — EzShops now runs on Folia servers. All scheduler calls are routed through a new `SchedulerAdapter` that transparently delegates to `GlobalRegionScheduler` / `AsyncScheduler` on Folia and to `BukkitScheduler` on Paper/Spigot/Bukkit. The `folia-supported: true` flag has been added to `plugin.yml`.
+
+### Changed
+- **EzBoost engine improvement** — reflective access to EzBoost's price-multiplier API is now cached after the first lookup. `Class.forName`, `getMethod`, and `getPlugin` are no longer called on every transaction; instead, resolved `Method` references are reused for the lifetime of the server.
+
 ## [2.5.0] - 2026-05-11
 
 This version we focussed on adding **Team Shops**, a full team-based economy layer built on top of [TeamsAPI](https://modrinth.com/plugin/teams-api). Teams get their own market, shared treasury, stock pool, and role-based pricing, all accessible through a new `/teamshop` command.

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.skyblockexp</groupId>
     <artifactId>ezshops</artifactId>
-    <version>2.5.0</version>
+    <version>2.5.1</version>
     <name>EzShops Plugin</name>
     <description>Standalone plugin providing the Skyblock shop command and sign shops.</description>
     <packaging>jar</packaging>

--- a/src/main/java/com/skyblockexp/ezshops/bootstrap/CoreShopComponent.java
+++ b/src/main/java/com/skyblockexp/ezshops/bootstrap/CoreShopComponent.java
@@ -88,6 +88,7 @@ public final class CoreShopComponent implements PluginComponent {
 
         pricingManager = new ShopPricingManager(plugin, dynamicPricingConfiguration);
         transactionService = new ShopTransactionService(pricingManager, economy, transactionMessages);
+        transactionService.setEzBoostBridge(new com.skyblockexp.ezshops.shop.EzBoostBridge(plugin.getLogger()));
         // Hook service for executing commands on buy/sell
         com.skyblockexp.ezshops.hook.TransactionHookService hookService = new com.skyblockexp.ezshops.hook.TransactionHookService(plugin);
         transactionService.setTransactionHookService(hookService);

--- a/src/main/java/com/skyblockexp/ezshops/common/CompatibilityUtil.java
+++ b/src/main/java/com/skyblockexp/ezshops/common/CompatibilityUtil.java
@@ -22,6 +22,7 @@ public final class CompatibilityUtil {
     
     private static Boolean isPaper = null;
     private static Boolean isSpigot = null;
+    private static Boolean isFolia = null;
     private static Boolean hasPersistentData = null;
     private static Integer minecraftVersion = null;
 
@@ -82,12 +83,33 @@ public final class CompatibilityUtil {
     }
 
     /**
+     * Detects if the server is running Folia (the threaded-region fork of Paper).
+     * On Folia, the standard BukkitScheduler sync tasks are unsupported; callers must
+     * use the region or global-region schedulers instead.
+     *
+     * @return true if Folia is detected
+     */
+    public static boolean isFolia() {
+        if (isFolia == null) {
+            try {
+                Class.forName("io.papermc.paper.threadedregions.RegionizedServer");
+                isFolia = true;
+            } catch (ClassNotFoundException e) {
+                isFolia = false;
+            }
+        }
+        return isFolia;
+    }
+
+    /**
      * Gets the server type as a string for logging/debugging.
      *
-     * @return "Paper", "Spigot", or "Bukkit"
+     * @return "Folia", "Paper", "Spigot", or "Bukkit"
      */
     public static String getServerType() {
-        if (isPaper()) {
+        if (isFolia()) {
+            return "Folia";
+        } else if (isPaper()) {
             return "Paper";
         } else if (isSpigot()) {
             return "Spigot";

--- a/src/main/java/com/skyblockexp/ezshops/common/SchedulerAdapter.java
+++ b/src/main/java/com/skyblockexp/ezshops/common/SchedulerAdapter.java
@@ -1,0 +1,143 @@
+package com.skyblockexp.ezshops.common;
+
+import org.bukkit.Bukkit;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.scheduler.BukkitTask;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Unified scheduler abstraction that transparently supports both the standard
+ * Bukkit/Paper scheduler and the Folia regional scheduler API.
+ *
+ * <p>On Folia, sync tasks are dispatched to the {@code GlobalRegionScheduler}
+ * and async tasks to the {@code AsyncScheduler}. On all other server
+ * implementations the familiar {@code BukkitScheduler} is used.</p>
+ *
+ * <p>All callers should use this class instead of calling
+ * {@code Bukkit.getScheduler()} or {@code plugin.getServer().getScheduler()}
+ * directly so that the plugin remains Folia-compatible.</p>
+ */
+public final class SchedulerAdapter {
+
+    private static final boolean FOLIA = CompatibilityUtil.isFolia();
+
+    /** Ticks → milliseconds conversion (1 tick = 50 ms at 20 TPS). */
+    private static final long MILLIS_PER_TICK = 50L;
+
+    private SchedulerAdapter() {}
+
+    // -------------------------------------------------------------------------
+    // Sync tasks (main thread / global region on Folia)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Schedules a one-shot task to run on the server's primary thread (or Folia's
+     * global region) as soon as possible.
+     *
+     * @param plugin the owning plugin
+     * @param task   the runnable to execute
+     * @return a handle that can be used to cancel the task
+     */
+    public static TaskHandle runTask(Plugin plugin, Runnable task) {
+        if (FOLIA) {
+            var scheduled = Bukkit.getGlobalRegionScheduler().run(plugin, st -> task.run());
+            return foliaHandle(scheduled);
+        }
+        BukkitTask bt = Bukkit.getScheduler().runTask(plugin, task);
+        return bukkitHandle(bt);
+    }
+
+    /**
+     * Schedules a repeating task on the server's primary thread (or Folia's global
+     * region).
+     *
+     * @param plugin      the owning plugin
+     * @param task        the runnable to execute each period
+     * @param delayTicks  initial delay in ticks
+     * @param periodTicks repeat interval in ticks
+     * @return a handle that can be used to cancel the task
+     */
+    public static TaskHandle runTaskTimer(Plugin plugin, Runnable task, long delayTicks, long periodTicks) {
+        if (FOLIA) {
+            var scheduled = Bukkit.getGlobalRegionScheduler()
+                    .runAtFixedRate(plugin, st -> task.run(), Math.max(1, delayTicks), Math.max(1, periodTicks));
+            return foliaHandle(scheduled);
+        }
+        BukkitTask bt = Bukkit.getScheduler().runTaskTimer(plugin, task, delayTicks, periodTicks);
+        return bukkitHandle(bt);
+    }
+
+    // -------------------------------------------------------------------------
+    // Async tasks
+    // -------------------------------------------------------------------------
+
+    /**
+     * Schedules a one-shot task to run asynchronously off the main thread.
+     *
+     * @param plugin the owning plugin
+     * @param task   the runnable to execute
+     * @return a handle that can be used to cancel the task
+     */
+    public static TaskHandle runTaskAsync(Plugin plugin, Runnable task) {
+        if (FOLIA) {
+            var scheduled = Bukkit.getAsyncScheduler().runNow(plugin, st -> task.run());
+            return foliaHandle(scheduled);
+        }
+        BukkitTask bt = Bukkit.getScheduler().runTaskAsynchronously(plugin, task);
+        return bukkitHandle(bt);
+    }
+
+    /**
+     * Schedules a repeating async task.
+     *
+     * @param plugin      the owning plugin
+     * @param task        the runnable to execute each period
+     * @param delayTicks  initial delay in ticks (converted to milliseconds for Folia)
+     * @param periodTicks repeat interval in ticks (converted to milliseconds for Folia)
+     * @return a handle that can be used to cancel the task
+     */
+    public static TaskHandle runTaskTimerAsync(Plugin plugin, Runnable task, long delayTicks, long periodTicks) {
+        if (FOLIA) {
+            long delayMs = Math.max(MILLIS_PER_TICK, delayTicks * MILLIS_PER_TICK);
+            long periodMs = Math.max(MILLIS_PER_TICK, periodTicks * MILLIS_PER_TICK);
+            var scheduled = Bukkit.getAsyncScheduler()
+                    .runAtFixedRate(plugin, st -> task.run(), delayMs, periodMs, TimeUnit.MILLISECONDS);
+            return foliaHandle(scheduled);
+        }
+        BukkitTask bt = Bukkit.getScheduler().runTaskTimerAsynchronously(plugin, task, delayTicks, periodTicks);
+        return bukkitHandle(bt);
+    }
+
+    // -------------------------------------------------------------------------
+    // Internal handle factories
+    // -------------------------------------------------------------------------
+
+    private static TaskHandle bukkitHandle(BukkitTask bt) {
+        return new TaskHandle() {
+            @Override
+            public void cancel() {
+                bt.cancel();
+            }
+
+            @Override
+            public boolean isCancelled() {
+                return bt.isCancelled();
+            }
+        };
+    }
+
+    private static TaskHandle foliaHandle(io.papermc.paper.threadedregions.scheduler.ScheduledTask st) {
+        return new TaskHandle() {
+            @Override
+            public void cancel() {
+                st.cancel();
+            }
+
+            @Override
+            public boolean isCancelled() {
+                return st.isCancelled();
+            }
+        };
+    }
+}

--- a/src/main/java/com/skyblockexp/ezshops/common/TaskHandle.java
+++ b/src/main/java/com/skyblockexp/ezshops/common/TaskHandle.java
@@ -1,0 +1,14 @@
+package com.skyblockexp.ezshops.common;
+
+/**
+ * Platform-agnostic handle for a scheduled task.
+ * Wraps both {@code BukkitTask} (Bukkit/Paper) and Folia's {@code ScheduledTask}.
+ */
+public interface TaskHandle {
+
+    /** Requests cancellation of the task. */
+    void cancel();
+
+    /** Returns true if the task has been cancelled. */
+    boolean isCancelled();
+}

--- a/src/main/java/com/skyblockexp/ezshops/gui/ShopMenu.java
+++ b/src/main/java/com/skyblockexp/ezshops/gui/ShopMenu.java
@@ -172,7 +172,7 @@ public class ShopMenu implements Listener {
         if (Bukkit.isPrimaryThread()) {
             refreshTask.run();
         } else {
-            plugin.getServer().getScheduler().runTask(plugin, refreshTask);
+            com.skyblockexp.ezshops.common.SchedulerAdapter.runTask(plugin, refreshTask);
         }
     }
 
@@ -241,7 +241,7 @@ public class ShopMenu implements Listener {
             return;
         }
         if (ShopInventoryComposer.ACTION_OPEN_MAIN_MENU.equalsIgnoreCase(action)) {
-            plugin.getServer().getScheduler().runTask(plugin, () -> openMainMenu(player));
+            com.skyblockexp.ezshops.common.SchedulerAdapter.runTask(plugin, () -> openMainMenu(player));
             return;
         }
         if (ShopInventoryComposer.ACTION_PLAY_SOUND.equalsIgnoreCase(action)) {
@@ -259,7 +259,7 @@ public class ShopMenu implements Listener {
             if (cmd != null) {
                 player.closeInventory();
                 String resolved = cmd.replace("{player}", player.getName());
-                plugin.getServer().getScheduler().runTask(plugin,
+                com.skyblockexp.ezshops.common.SchedulerAdapter.runTask(plugin,
                         () -> player.performCommand(resolved));
             }
             return;
@@ -289,13 +289,13 @@ public class ShopMenu implements Listener {
         }
 
         if (ShopInventoryComposer.ACTION_BACK.equalsIgnoreCase(action)) {
-            plugin.getServer().getScheduler().runTask(plugin, () -> openMainMenu((Player) event.getWhoClicked()));
+            com.skyblockexp.ezshops.common.SchedulerAdapter.runTask(plugin, () -> openMainMenu((Player) event.getWhoClicked()));
             return;
         }
 
         if (ShopInventoryComposer.ACTION_PREVIOUS.equalsIgnoreCase(action)) {
             if (categoryHolder.hasPreviousPage()) {
-                plugin.getServer().getScheduler().runTask(plugin, () -> inventoryComposer.openCategoryMenu(
+                com.skyblockexp.ezshops.common.SchedulerAdapter.runTask(plugin, () -> inventoryComposer.openCategoryMenu(
                         player, categoryHolder.category(), categoryHolder.page() - 1, resolvePlayerIslandLevel(player),
                         ignoreIslandRequirements));
             }
@@ -304,7 +304,7 @@ public class ShopMenu implements Listener {
 
         if (ShopInventoryComposer.ACTION_NEXT.equalsIgnoreCase(action)) {
             if (categoryHolder.hasNextPage()) {
-                plugin.getServer().getScheduler().runTask(plugin, () -> inventoryComposer.openCategoryMenu(
+                com.skyblockexp.ezshops.common.SchedulerAdapter.runTask(plugin, () -> inventoryComposer.openCategoryMenu(
                         player, categoryHolder.category(), categoryHolder.page() + 1, resolvePlayerIslandLevel(player),
                         ignoreIslandRequirements));
             }
@@ -330,7 +330,7 @@ public class ShopMenu implements Listener {
         String action = CompatibilityUtil.get(container, actionKey, PersistentDataType.STRING);
         if (ShopInventoryComposer.ACTION_PREVIOUS.equalsIgnoreCase(action)) {
             if (holder.hasPreviousPage()) {
-                plugin.getServer().getScheduler().runTask(plugin,
+                com.skyblockexp.ezshops.common.SchedulerAdapter.runTask(plugin,
                         () -> inventoryComposer.populateFlatMenu(holder, holder.page() - 1,
                                 resolvePlayerIslandLevel(player), ignoreIslandRequirements));
             }
@@ -339,7 +339,7 @@ public class ShopMenu implements Listener {
 
         if (ShopInventoryComposer.ACTION_NEXT.equalsIgnoreCase(action)) {
             if (holder.hasNextPage()) {
-                plugin.getServer().getScheduler().runTask(plugin,
+                com.skyblockexp.ezshops.common.SchedulerAdapter.runTask(plugin,
                         () -> inventoryComposer.populateFlatMenu(holder, holder.page() + 1,
                                 resolvePlayerIslandLevel(player), ignoreIslandRequirements));
             }
@@ -369,7 +369,7 @@ public class ShopMenu implements Listener {
         event.setCancelled(true);
         pendingCustomInputs.remove(playerId);
 
-        plugin.getServer().getScheduler().runTask(plugin,
+        com.skyblockexp.ezshops.common.SchedulerAdapter.runTask(plugin,
                 () -> handleCustomTransactionInput(event.getPlayer(), pending, event.getMessage()));
     }
 
@@ -394,7 +394,7 @@ public class ShopMenu implements Listener {
                     player.closeInventory();
                     plugin.getServer().dispatchCommand(player, commandToRun);
                 } else {
-                    plugin.getServer().getScheduler().runTask(plugin, () -> openCategory(player, category));
+                    com.skyblockexp.ezshops.common.SchedulerAdapter.runTask(plugin, () -> openCategory(player, category));
                 }
                 return;
             }
@@ -406,7 +406,7 @@ public class ShopMenu implements Listener {
             PersistentDataContainer container) {
         String action = CompatibilityUtil.get(container, actionKey, PersistentDataType.STRING);
         if (ShopInventoryComposer.ACTION_BACK.equalsIgnoreCase(action)) {
-            plugin.getServer().getScheduler().runTask(plugin, () -> openCategory(player, holder.category()));
+            com.skyblockexp.ezshops.common.SchedulerAdapter.runTask(plugin, () -> openCategory(player, holder.category()));
             return;
         }
 
@@ -444,7 +444,7 @@ public class ShopMenu implements Listener {
                 player.sendMessage(guiMessages.common().itemCannotBePurchased());
                 return;
             }
-            plugin.getServer().getScheduler().runTask(plugin,
+            com.skyblockexp.ezshops.common.SchedulerAdapter.runTask(plugin,
                     () -> openQuantityMenu(player, category, item, ShopTransactionType.BUY));
             return;
         }
@@ -454,7 +454,7 @@ public class ShopMenu implements Listener {
             return;
         }
 
-        plugin.getServer().getScheduler().runTask(plugin,
+        com.skyblockexp.ezshops.common.SchedulerAdapter.runTask(plugin,
                 () -> openQuantityMenu(player, category, item, ShopTransactionType.SELL));
     }
 
@@ -595,7 +595,7 @@ public class ShopMenu implements Listener {
         }
 
         int islandLevel = resolvePlayerIslandLevel(player);
-        plugin.getServer().getScheduler().runTask(plugin,
+        com.skyblockexp.ezshops.common.SchedulerAdapter.runTask(plugin,
                 () -> openQuantityMenu(player, category, item, holder.type(), islandLevel));
     }
 

--- a/src/main/java/com/skyblockexp/ezshops/gui/quicksell/QuickSellMenu.java
+++ b/src/main/java/com/skyblockexp/ezshops/gui/quicksell/QuickSellMenu.java
@@ -10,6 +10,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
@@ -187,9 +188,11 @@ public class QuickSellMenu implements Listener {
         }
 
         // Allow the drag; schedule a price refresh for the next tick
-        Bukkit.getScheduler().runTask(
-                Bukkit.getPluginManager().getPlugin("EzShops"),
-                () -> refreshPriceDisplay(topInv, player));
+        Plugin ezShopsPlugin = Bukkit.getPluginManager().getPlugin("EzShops");
+        if (ezShopsPlugin != null) {
+            com.skyblockexp.ezshops.common.SchedulerAdapter.runTask(ezShopsPlugin,
+                    () -> refreshPriceDisplay(topInv, player));
+        }
     }
 
     @EventHandler(priority = EventPriority.MONITOR)

--- a/src/main/java/com/skyblockexp/ezshops/hook/TransactionHookService.java
+++ b/src/main/java/com/skyblockexp/ezshops/hook/TransactionHookService.java
@@ -61,7 +61,7 @@ public class TransactionHookService {
             formatted.add(replaced);
         }
 
-        plugin.getServer().getScheduler().runTask(plugin, () -> {
+        com.skyblockexp.ezshops.common.SchedulerAdapter.runTask(plugin, () -> {
             boolean effectiveConsole = runAsConsole;
             if (!effectiveConsole) {
                 // require explicit permission to run commands as the player

--- a/src/main/java/com/skyblockexp/ezshops/playershop/PlayerShopSetupMenu.java
+++ b/src/main/java/com/skyblockexp/ezshops/playershop/PlayerShopSetupMenu.java
@@ -183,7 +183,7 @@ public final class PlayerShopSetupMenu implements Listener {
         }
         event.setCancelled(true);
         String message = event.getMessage();
-        plugin.getServer().getScheduler().runTask(plugin, () -> handleChatInput(event.getPlayer(), message));
+        com.skyblockexp.ezshops.common.SchedulerAdapter.runTask(plugin, () -> handleChatInput(event.getPlayer(), message));
     }
 
     @EventHandler

--- a/src/main/java/com/skyblockexp/ezshops/service/SpigotUpdateChecker.java
+++ b/src/main/java/com/skyblockexp/ezshops/service/SpigotUpdateChecker.java
@@ -1,5 +1,6 @@
 package com.skyblockexp.ezshops.service;
 
+import com.skyblockexp.ezshops.common.SchedulerAdapter;
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
@@ -18,7 +19,7 @@ public final class SpigotUpdateChecker {
     }
 
     public void checkForUpdates() {
-        plugin.getServer().getScheduler().runTaskAsynchronously(plugin, () -> {
+        SchedulerAdapter.runTaskAsync(plugin, () -> {
             try {
                 String latestVersion = fetchLatestVersion();
                 if (latestVersion == null || latestVersion.isBlank()) {

--- a/src/main/java/com/skyblockexp/ezshops/shop/EzBoostBridge.java
+++ b/src/main/java/com/skyblockexp/ezshops/shop/EzBoostBridge.java
@@ -1,0 +1,175 @@
+package com.skyblockexp.ezshops.shop;
+
+import org.bukkit.entity.Player;
+
+import java.lang.reflect.Method;
+import java.util.Collection;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Caches reflective access to EzBoost's API so that per-transaction multiplier
+ * lookups never re-resolve {@code Class.forName} or {@code getMethod} after the
+ * first successful setup.
+ *
+ * <p>Boost-class and effect-class {@link Method} objects are captured from the
+ * first live instance encountered and reused for all subsequent calls.  If
+ * EzBoost is absent or the API shape changes the methods return the neutral
+ * multiplier {@code 1.0}.</p>
+ */
+public final class EzBoostBridge {
+
+    static final double NEUTRAL = 1.0;
+
+    private static final String SELL_EFFECT = "ezshops_sellprice";
+    private static final String BUY_EFFECT  = "ezshops_discountboost";
+
+    private final Logger logger;
+
+    // ---------- lazily resolved, written once, then read-only ----------
+    private volatile boolean setupDone = false;
+    private volatile boolean available = false;
+
+    // Manager-level methods (keyed on EzBoostAPI / BoostManager class)
+    private Method mGetBoostManager; // static: () → BoostManager
+    private Method mGetBoosts;        // instance: (Player) → Map
+    private Method mIsActive;         // instance: (Player, String) → Boolean
+
+    // Boost-level and effect-level methods (keyed on first instance's class)
+    private Method mGetKey;       // boost.key()
+    private Method mGetEffects;   // boost.effects() → Collection
+    private Method mCustomName;   // effect.customName()
+    private Method mAmplifier;    // effect.amplifier() → Number
+
+    public EzBoostBridge(Logger logger) {
+        this.logger = logger;
+    }
+
+    // -------------------------------------------------------------------------
+    // Public API
+    // -------------------------------------------------------------------------
+
+    double getSellMultiplier(Player player) {
+        ensureSetup();
+        if (!available) return NEUTRAL;
+        try {
+            return computeMultiplier(player, SELL_EFFECT, true);
+        } catch (Throwable t) {
+            logger.log(Level.FINE, "EzBoostBridge sell multiplier error", t);
+            return NEUTRAL;
+        }
+    }
+
+    double getBuyMultiplier(Player player) {
+        ensureSetup();
+        if (!available) return NEUTRAL;
+        try {
+            double m = computeMultiplier(player, BUY_EFFECT, false);
+            return Math.max(0.0, m);
+        } catch (Throwable t) {
+            logger.log(Level.FINE, "EzBoostBridge buy multiplier error", t);
+            return NEUTRAL;
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Internal
+    // -------------------------------------------------------------------------
+
+    @SuppressWarnings("unchecked")
+    private double computeMultiplier(Player player, String effectKey, boolean additive) throws Throwable {
+        Object manager = mGetBoostManager.invoke(null);
+        if (manager == null) return NEUTRAL;
+
+        Map<String, Object> boosts = (Map<String, Object>) mGetBoosts.invoke(manager, player);
+        if (boosts == null || boosts.isEmpty()) return NEUTRAL;
+
+        // Ensure boost/effect methods are resolved from the first live instance
+        ensureBoostMethods(manager, player, boosts);
+
+        double multiplier = NEUTRAL;
+        for (Object boost : boosts.values()) {
+            String key = (String) mGetKey.invoke(boost);
+            if (!Boolean.TRUE.equals(mIsActive.invoke(manager, player, key))) continue;
+
+            Collection<Object> effects = (Collection<Object>) mGetEffects.invoke(boost);
+            if (effects == null) continue;
+            for (Object effect : effects) {
+                if (effectKey.equals(mCustomName.invoke(effect))) {
+                    Number amp = (Number) mAmplifier.invoke(effect);
+                    if (additive) {
+                        multiplier += amp.doubleValue() / 100.0;
+                    } else {
+                        multiplier -= amp.doubleValue() / 100.0;
+                    }
+                }
+            }
+        }
+        return multiplier;
+    }
+
+    private void ensureSetup() {
+        if (setupDone) return;
+        synchronized (this) {
+            if (setupDone) return;
+            setupDone = true;
+            trySetup();
+        }
+    }
+
+    private void trySetup() {
+        org.bukkit.plugin.Plugin ezBoostPlugin =
+                org.bukkit.Bukkit.getPluginManager().getPlugin("EzBoost");
+        if (ezBoostPlugin == null) return;
+        try {
+            ClassLoader cl = ezBoostPlugin.getClass().getClassLoader();
+            Class<?> apiClass = Class.forName("com.skyblockexp.ezboost.api.EzBoostAPI", true, cl);
+            mGetBoostManager = apiClass.getMethod("getBoostManager");
+
+            // Obtain the manager instance to discover its class for getBoosts / isActive
+            Object manager = mGetBoostManager.invoke(null);
+            if (manager == null) {
+                logger.fine("EzBoostBridge: getBoostManager() returned null; retrying on first transaction.");
+                setupDone = false; // allow retry
+                return;
+            }
+            Class<?> managerClass = manager.getClass();
+            mGetBoosts = managerClass.getMethod("getBoosts", Player.class);
+            mIsActive  = managerClass.getMethod("isActive", Player.class, String.class);
+
+            available = true;
+            logger.fine("EzBoostBridge: manager-level setup complete.");
+            // Note: boost/effect methods are resolved lazily from the first live instance.
+        } catch (Throwable t) {
+            logger.log(Level.FINE, "EzBoostBridge setup failed; integration disabled.", t);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private synchronized void ensureBoostMethods(Object manager, Player player,
+                                                  Map<String, Object> boosts) throws Throwable {
+        if (mGetKey != null) return; // already resolved
+
+        Object firstBoost = boosts.values().iterator().next();
+        Class<?> boostClass = firstBoost.getClass();
+        mGetKey     = boostClass.getMethod("key");
+        mGetEffects = boostClass.getMethod("effects");
+
+        // Find a non-empty effects collection to resolve the effect class
+        for (Object boost : boosts.values()) {
+            Collection<Object> effects = (Collection<Object>) mGetEffects.invoke(boost);
+            if (effects != null && !effects.isEmpty()) {
+                Object firstEffect = effects.iterator().next();
+                Class<?> effectClass = firstEffect.getClass();
+                mCustomName = effectClass.getMethod("customName");
+                mAmplifier  = effectClass.getMethod("amplifier");
+                logger.fine("EzBoostBridge: boost/effect method setup complete.");
+                return;
+            }
+        }
+        // No effects found yet — will retry next call
+        mGetKey = null;
+    }
+}
+

--- a/src/main/java/com/skyblockexp/ezshops/shop/ShopRotationManager.java
+++ b/src/main/java/com/skyblockexp/ezshops/shop/ShopRotationManager.java
@@ -10,10 +10,11 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.logging.Level;
+import com.skyblockexp.ezshops.common.SchedulerAdapter;
+import com.skyblockexp.ezshops.common.TaskHandle;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.plugin.java.JavaPlugin;
-import org.bukkit.scheduler.BukkitTask;
 
 /**
  * Handles automatic advancement of configured shop rotations.
@@ -25,7 +26,7 @@ public final class ShopRotationManager {
     private final ShopMenu shopMenu;
     private final File stateFile;
     private final Map<String, RotationState> rotationStates = new LinkedHashMap<>();
-    private BukkitTask task;
+    private TaskHandle task;
 
     public ShopRotationManager(JavaPlugin plugin, ShopPricingManager pricingManager, ShopMenu shopMenu) {
         this.plugin = Objects.requireNonNull(plugin, "plugin");
@@ -51,7 +52,7 @@ public final class ShopRotationManager {
         if (task != null) {
             task.cancel();
         }
-        task = plugin.getServer().getScheduler().runTaskTimer(plugin, this::tick, 20L, 20L);
+        task = SchedulerAdapter.runTaskTimer(plugin, this::tick, 20L, 20L);
     }
 
     public void disable() {

--- a/src/main/java/com/skyblockexp/ezshops/shop/ShopSignListener.java
+++ b/src/main/java/com/skyblockexp/ezshops/shop/ShopSignListener.java
@@ -120,7 +120,7 @@ public class ShopSignListener implements Listener {
 
         Block block = event.getBlock();
         if (block != null) {
-            Bukkit.getScheduler().runTask(plugin, () -> storeSignData(block, action, material, amount));
+            com.skyblockexp.ezshops.common.SchedulerAdapter.runTask(plugin, () -> storeSignData(block, action, material, amount));
         }
 
         if (player != null) {

--- a/src/main/java/com/skyblockexp/ezshops/shop/ShopTransactionService.java
+++ b/src/main/java/com/skyblockexp/ezshops/shop/ShopTransactionService.java
@@ -49,6 +49,7 @@ public class ShopTransactionService {
     private com.skyblockexp.ezshops.teams.TeamsIntegration teamsIntegration;
     private com.skyblockexp.ezshops.teams.TeamTreasury teamTreasury;
     private double treasurySplit = 0.0;
+    private EzBoostBridge ezBoostBridge;
 
     public ShopTransactionService(ShopPricingManager pricingManager, Economy economy,
             ShopMessageConfiguration.TransactionMessages transactionMessages) {
@@ -58,6 +59,10 @@ public class ShopTransactionService {
         this.successMessages = transactionMessages.success();
         this.notificationMessages = transactionMessages.notifications();
         this.customItemMessages = transactionMessages.customItems();
+    }
+
+    public void setEzBoostBridge(EzBoostBridge bridge) {
+        this.ezBoostBridge = bridge;
     }
 
     public void setTransactionHookService(com.skyblockexp.ezshops.hook.TransactionHookService hookService) {
@@ -83,122 +88,13 @@ public class ShopTransactionService {
     }
 
     private double getSellPriceMultiplier(Player player) {
-        try {
-            // Get the EzBoost plugin instance to access its class loader
-            org.bukkit.plugin.Plugin ezBoostPlugin = org.bukkit.Bukkit.getPluginManager().getPlugin("EzBoost");
-            if (ezBoostPlugin == null) {
-                return 1.0;
-            }
-            ClassLoader ezBoostClassLoader = ezBoostPlugin.getClass().getClassLoader();
-
-            // Check if EzBoost classes are available using the plugin's class loader
-            Class<?> ezBoostAPIClass = Class.forName("com.skyblockexp.ezboost.api.EzBoostAPI", true, ezBoostClassLoader);
-
-            java.lang.reflect.Method getBoostManagerMethod = ezBoostAPIClass.getMethod("getBoostManager");
-            Object boostManager = getBoostManagerMethod.invoke(null);
-            if (boostManager == null) {
-                return 1.0;
-            }
-
-            java.lang.reflect.Method getBoostsMethod = boostManager.getClass().getMethod("getBoosts", Player.class);
-            @SuppressWarnings("unchecked")
-            Map<String, Object> boosts = (Map<String, Object>) getBoostsMethod.invoke(boostManager, player);
-            double multiplier = 1.0;
-
-            for (Object boost : boosts.values()) {
-                java.lang.reflect.Method isActiveMethod = boostManager.getClass().getMethod("isActive", Player.class, String.class);
-                java.lang.reflect.Method getKeyMethod = boost.getClass().getMethod("key");
-                String key = (String) getKeyMethod.invoke(boost);
-
-                Boolean isActive = (Boolean) isActiveMethod.invoke(boostManager, player, key);
-                if (isActive) {
-                    java.lang.reflect.Method getEffectsMethod = boost.getClass().getMethod("effects");
-                    @SuppressWarnings("unchecked")
-                    java.util.Collection<Object> effects = (java.util.Collection<Object>) getEffectsMethod.invoke(boost);
-
-                    for (Object effect : effects) {
-                        java.lang.reflect.Method getCustomNameMethod = effect.getClass().getMethod("customName");
-                        String customName = (String) getCustomNameMethod.invoke(effect);
-                        if ("ezshops_sellprice".equals(customName)) {
-                            java.lang.reflect.Method getAmplifierMethod = effect.getClass().getMethod("amplifier");
-                            Number amplifier = (Number) getAmplifierMethod.invoke(effect);
-                            multiplier += amplifier.doubleValue() / 100.0;
-                        }
-                    }
-                }
-            }
-            return multiplier;
-        } catch (ClassNotFoundException e) {
-            // EzBoost not available, return default multiplier
-            return 1.0;
-        } catch (Exception e) {
-            // EzBoost integration failed, return default multiplier
-            return 1.0;
-        }
+        if (ezBoostBridge == null) return EzBoostBridge.NEUTRAL;
+        return ezBoostBridge.getSellMultiplier(player);
     }
 
     private double getBuyPriceMultiplier(Player player) {
-        /**
-         * Retrieves the active EzBoost discount boost for the player and converts it
-         * into a price multiplier.
-         *
-         * Example:
-         *  - 20% discount boost -> returns 0.8
-         *  - 50% discount boost -> returns 0.5
-         *
-         * If EzBoost is not present or an error occurs, defaults to 1.0 (no discount).
-         * Multiplier is clamped to a minimum of 0.0 to prevent negative prices.
-         */
-        try {
-            org.bukkit.plugin.Plugin ezBoostPlugin = org.bukkit.Bukkit.getPluginManager().getPlugin("EzBoost");
-            if (ezBoostPlugin == null) {
-                return 1.0;
-            }
-
-            ClassLoader ezBoostClassLoader = ezBoostPlugin.getClass().getClassLoader();
-            Class<?> ezBoostAPIClass = Class.forName("com.skyblockexp.ezboost.api.EzBoostAPI", true, ezBoostClassLoader);
-
-            java.lang.reflect.Method getBoostManagerMethod = ezBoostAPIClass.getMethod("getBoostManager");
-            Object boostManager = getBoostManagerMethod.invoke(null);
-            if (boostManager == null) {
-                return 1.0;
-            }
-
-            java.lang.reflect.Method getBoostsMethod = boostManager.getClass().getMethod("getBoosts", Player.class);
-            @SuppressWarnings("unchecked")
-            Map<String, Object> boosts = (Map<String, Object>) getBoostsMethod.invoke(boostManager, player);
-
-            double multiplier = 1.0;
-
-            for (Object boost : boosts.values()) {
-                java.lang.reflect.Method isActiveMethod = boostManager.getClass().getMethod("isActive", Player.class, String.class);
-                java.lang.reflect.Method getKeyMethod = boost.getClass().getMethod("key");
-                String key = (String) getKeyMethod.invoke(boost);
-
-                Boolean isActive = (Boolean) isActiveMethod.invoke(boostManager, player, key);
-                if (isActive) {
-                    java.lang.reflect.Method getEffectsMethod = boost.getClass().getMethod("effects");
-                    @SuppressWarnings("unchecked")
-                    Collection<Object> effects = (Collection<Object>) getEffectsMethod.invoke(boost);
-
-                    for (Object effect : effects) {
-                        java.lang.reflect.Method getCustomNameMethod = effect.getClass().getMethod("customName");
-                        String customName = (String) getCustomNameMethod.invoke(effect);
-
-                        if ("ezshops_discountboost".equals(customName)) {
-                            java.lang.reflect.Method getAmplifierMethod = effect.getClass().getMethod("amplifier");
-                            Number amplifier = (Number) getAmplifierMethod.invoke(effect);
-
-                            multiplier -= amplifier.doubleValue() / 100.0;
-                        }
-                    }
-                }
-            }
-
-            return Math.max(0.0, multiplier);
-        } catch (Exception e) {
-            return 1.0;
-        }
+        if (ezBoostBridge == null) return EzBoostBridge.NEUTRAL;
+        return ezBoostBridge.getBuyMultiplier(player);
     }
 
     private double getTeamSellMultiplier(Player player) {

--- a/src/main/java/com/skyblockexp/ezshops/shop/sign/SignShopSetupMenu.java
+++ b/src/main/java/com/skyblockexp/ezshops/shop/sign/SignShopSetupMenu.java
@@ -133,7 +133,7 @@ public final class SignShopSetupMenu implements Listener {
         state.awaitingSearchInput = false;
         state.selectionInventory = null;
         state.inventory = null;
-        Bukkit.getScheduler().runTask(plugin, () -> {
+        com.skyblockexp.ezshops.common.SchedulerAdapter.runTask(plugin, () -> {
             if (player.isOnline()) {
                 player.closeInventory();
             }
@@ -288,7 +288,7 @@ public final class SignShopSetupMenu implements Listener {
                 return;
             }
             if (state.inventory != null && openMenus.containsKey(player.getUniqueId())) {
-                Bukkit.getScheduler().runTask(plugin, () -> {
+                com.skyblockexp.ezshops.common.SchedulerAdapter.runTask(plugin, () -> {
                     if (!player.getOpenInventory().getTopInventory().equals(state.inventory)
                             && player.isOnline()) {
                         player.openInventory(state.inventory);
@@ -326,7 +326,7 @@ public final class SignShopSetupMenu implements Listener {
         }
         event.setCancelled(true);
         String message = event.getMessage();
-        Bukkit.getScheduler().runTask(plugin, () -> handleCatalogSearchInput(player, state, message));
+        com.skyblockexp.ezshops.common.SchedulerAdapter.runTask(plugin, () -> handleCatalogSearchInput(player, state, message));
     }
 
     private void handlePlayerInventoryClick(InventoryClickEvent event, Player player, MenuState state) {
@@ -477,7 +477,7 @@ public final class SignShopSetupMenu implements Listener {
             state.pendingItemSlot = -1;
             state.reopenToPlanner = true;
             state.awaitingSearchInput = false;
-            Bukkit.getScheduler().runTask(plugin, () -> player.openInventory(state.inventory));
+            com.skyblockexp.ezshops.common.SchedulerAdapter.runTask(plugin, () -> player.openInventory(state.inventory));
             return;
         }
         if (slot == CATALOG_SLOT_SOURCE_TOGGLE) {
@@ -532,7 +532,7 @@ public final class SignShopSetupMenu implements Listener {
         state.pendingItemSlot = -1;
         state.awaitingSearchInput = false;
         state.reopenToPlanner = true;
-        Bukkit.getScheduler().runTask(plugin, () -> player.openInventory(state.inventory));
+        com.skyblockexp.ezshops.common.SchedulerAdapter.runTask(plugin, () -> player.openInventory(state.inventory));
     }
 
     private void handleCategorySelection(Player player, MenuState state, CatalogEntry entry) {
@@ -596,7 +596,7 @@ public final class SignShopSetupMenu implements Listener {
 
         state.awaitingSearchInput = false;
         state.reopenToPlanner = true;
-        Bukkit.getScheduler().runTask(plugin, () -> player.openInventory(state.inventory));
+        com.skyblockexp.ezshops.common.SchedulerAdapter.runTask(plugin, () -> player.openInventory(state.inventory));
     }
 
     private void handleCatalogSearchClick(Player player, MenuState state, ClickType click) {
@@ -1159,7 +1159,7 @@ public final class SignShopSetupMenu implements Listener {
         player.sendMessage((result.success() ? ChatColor.GREEN : ChatColor.RED) + result.message());
         if (result.success()) {
             openMenus.remove(player.getUniqueId());
-            Bukkit.getScheduler().runTask(plugin, () -> player.closeInventory());
+            com.skyblockexp.ezshops.common.SchedulerAdapter.runTask(plugin, () -> player.closeInventory());
         }
     }
 

--- a/src/main/java/com/skyblockexp/ezshops/stock/StockMarketManager.java
+++ b/src/main/java/com/skyblockexp/ezshops/stock/StockMarketManager.java
@@ -1,8 +1,9 @@
 package com.skyblockexp.ezshops.stock;
 
+import com.skyblockexp.ezshops.common.SchedulerAdapter;
+import com.skyblockexp.ezshops.common.TaskHandle;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.Plugin;
-import org.bukkit.scheduler.BukkitTask;
 import com.skyblockexp.ezshops.gui.shop.ShopTransactionType;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
@@ -31,7 +32,7 @@ public class StockMarketManager {
     private final StockHistoryManager historyManager = new StockHistoryManager();
 
     // Persistence
-    private BukkitTask saveTask;
+    private TaskHandle saveTask;
     private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
     /**
      * Call this during plugin/component enable to set up persistence.
@@ -52,7 +53,7 @@ public class StockMarketManager {
         }
         // Schedule periodic async save
         if (saveTask != null) saveTask.cancel();
-        saveTask = Bukkit.getScheduler().runTaskTimerAsynchronously(plugin, this::savePrices, saveIntervalTicks, saveIntervalTicks);
+        saveTask = SchedulerAdapter.runTaskTimerAsync(plugin, this::savePrices, saveIntervalTicks, saveIntervalTicks);
     }
 
     public void disablePersistence() {

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -4,6 +4,7 @@ main: com.skyblockexp.ezshops.EzShopsPlugin
 author: Shadow48402
 description: Standalone plugin providing the Skyblock shop command, sign shops, and player chest shops.
 api-version: 1.13
+folia-supported: true
 depend: [Vault]
 softdepend: [SkyblockExperience, EzScoreboard, SkyblockExperienceCommon, EzEconomy, EzBoost, TeamsAPI]
 commands:


### PR DESCRIPTION
### Added
- **Folia support** — EzShops now runs on Folia servers. All scheduler calls are routed through a new `SchedulerAdapter` that transparently delegates to `GlobalRegionScheduler` / `AsyncScheduler` on Folia and to `BukkitScheduler` on Paper/Spigot/Bukkit. The `folia-supported: true` flag has been added to `plugin.yml`.

### Changed
- **EzBoost engine improvement** — reflective access to EzBoost's price-multiplier API is now cached after the first lookup. `Class.forName`, `getMethod`, and `getPlugin` are no longer called on every transaction; instead, resolved `Method` references are reused for the lifetime of the server.