### PR TITLE
QuickSellMenu sells GUI items directly without checking player inventory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.5.5] - 2026-05-15
-
-### Fixed
-- **Quick Sell GUI shows "Nothing to sell" when sell fails after shift-click** — `handleConfirm` now distinguishes between a genuinely empty GUI and a GUI that has items but whose `sellDirect` call failed (e.g. economy down, dynamic price driven to $0.00 by a previous sale, rotation expired). The actual failure reason is shown to the player instead of the misleading "No items to sell." message. Items that failed to sell remain in the GUI so the player can retry.
-
 ## [2.5.4] - 2026-05-14
 
 ### Fixed
-- **Quick Sell GUI "Nothing to sell" after shift-click** - `handleConfirm` now calls a new `ShopTransactionService.sellDirect()` method that skips the player-inventory item count/removal steps. Previously, shift-clicking items into the GUI moved them out of the player's inventory, so the old `sell()` path found zero items and reported nothing to sell.
+- **Quick Sell GUI "Nothing to sell" after shift-click** — `handleConfirm` now calls a new `ShopTransactionService.sellDirect()` method that skips the player-inventory item count/removal steps. Previously, shift-clicking items into the GUI moved them out of the player's inventory, so the old `sell()` path found zero items and reported nothing to sell.
+- **Quick Sell GUI shows "Nothing to sell" when sell fails after shift-click** — `handleConfirm` now distinguishes between a genuinely empty GUI and a GUI that has items but whose `sellDirect` call failed (e.g. economy down, dynamic price driven to $0.00 by a previous sale, rotation expired). The actual failure reason is shown to the player instead of the misleading "No items to sell." message. Items that failed to sell remain in the GUI so the player can retry.
+- **Quick Sell GUI rejects rotation items even when directly sellable** — `sellDirect` and `isSellable` both applied a rotation-visibility check that belongs only in the main shop menu. The Quick Sell GUI is designed to accept any item with a configured sell price; rotation restrictions are now only enforced in `sell()`, which is the path used when a player types `/sell` or `/sellhand`.
+- **Legacy `shop.yml` item keys not found when using lowercase material names** — `loadLegacyEntries` now normalises every price key to `Material.name()` (e.g. `BIRCH_LOG`) before registering it in the price map. Previously, a config entry written as `birch_log:` was stored under the lowercase key, so `getPrice(Material.BIRCH_LOG)` could not find it, silently treating the item as unpriced.
 
 ## [2.5.3] - 2026-05-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Quick Sell GUI rejects rotation items even when directly sellable** — `sellDirect` and `isSellable` both applied a rotation-visibility check that belongs only in the main shop menu. The Quick Sell GUI is designed to accept any item with a configured sell price; rotation restrictions are now only enforced in `sell()`, which is the path used when a player types `/sell` or `/sellhand`.
 - **Legacy `shop.yml` item keys not found when using lowercase material names** — `loadLegacyEntries` now normalises every price key to `Material.name()` (e.g. `BIRCH_LOG`) before registering it in the price map. Previously, a config entry written as `birch_log:` was stored under the lowercase key, so `getPrice(Material.BIRCH_LOG)` could not find it, silently treating the item as unpriced.
 
+### Added
+- **Stripped log variants in the wood category** — all 9 stripped log types (`STRIPPED_OAK_LOG`, `STRIPPED_SPRUCE_LOG`, `STRIPPED_BIRCH_LOG`, `STRIPPED_JUNGLE_LOG`, `STRIPPED_ACACIA_LOG`, `STRIPPED_DARK_OAK_LOG`, `STRIPPED_MANGROVE_LOG`, `STRIPPED_PALE_OAK_LOG`, `STRIPPED_CHERRY_LOG`) are now included in the default `wood.yml` config so players can sell stripped logs with `/sellhand` and the Quick Sell GUI out of the box.
+- **Plank variants in the building category** — all 9 plank types (`OAK_PLANKS`, `SPRUCE_PLANKS`, `BIRCH_PLANKS`, `JUNGLE_PLANKS`, `ACACIA_PLANKS`, `DARK_OAK_PLANKS`, `MANGROVE_PLANKS`, `PALE_OAK_PLANKS`, `CHERRY_PLANKS`) are now included in the default `building.yml` config.
+
 ## [2.5.3] - 2026-05-14
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.5.5] - 2026-05-15
+
+### Fixed
+- **Quick Sell GUI shows "Nothing to sell" when sell fails after shift-click** — `handleConfirm` now distinguishes between a genuinely empty GUI and a GUI that has items but whose `sellDirect` call failed (e.g. economy down, dynamic price driven to $0.00 by a previous sale, rotation expired). The actual failure reason is shown to the player instead of the misleading "No items to sell." message. Items that failed to sell remain in the GUI so the player can retry.
+
 ## [2.5.4] - 2026-05-14
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - **Stripped log variants in the wood category** — all 9 stripped log types (`STRIPPED_OAK_LOG`, `STRIPPED_SPRUCE_LOG`, `STRIPPED_BIRCH_LOG`, `STRIPPED_JUNGLE_LOG`, `STRIPPED_ACACIA_LOG`, `STRIPPED_DARK_OAK_LOG`, `STRIPPED_MANGROVE_LOG`, `STRIPPED_PALE_OAK_LOG`, `STRIPPED_CHERRY_LOG`) are now included in the default `wood.yml` config so players can sell stripped logs with `/sellhand` and the Quick Sell GUI out of the box.
+- **Wood (all-bark) block variants in the wood category** — all 9 wood block types (`OAK_WOOD`, `SPRUCE_WOOD`, `BIRCH_WOOD`, `JUNGLE_WOOD`, `ACACIA_WOOD`, `DARK_OAK_WOOD`, `MANGROVE_WOOD`, `PALE_OAK_WOOD`, `CHERRY_WOOD`) are now included. Previously, attempting to `/sellhand` a "Birch Wood" block (as opposed to a "Birch Log") would return "That item is not configured in the shop."
 - **Plank variants in the building category** — all 9 plank types (`OAK_PLANKS`, `SPRUCE_PLANKS`, `BIRCH_PLANKS`, `JUNGLE_PLANKS`, `ACACIA_PLANKS`, `DARK_OAK_PLANKS`, `MANGROVE_PLANKS`, `PALE_OAK_PLANKS`, `CHERRY_PLANKS`) are now included in the default `building.yml` config.
 
 ## [2.5.3] - 2026-05-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.5.4] - 2026-05-14
+
+### Fixed
+- **Quick Sell GUI "Nothing to sell" after shift-click** - `handleConfirm` now calls a new `ShopTransactionService.sellDirect()` method that skips the player-inventory item count/removal steps. Previously, shift-clicking items into the GUI moved them out of the player's inventory, so the old `sell()` path found zero items and reported nothing to sell.
+
 ## [2.5.3] - 2026-05-14
 
 ### Fixed

--- a/docs/configuration/material-names.md
+++ b/docs/configuration/material-names.md
@@ -1,0 +1,188 @@
+---
+layout: default
+title: Material Names
+parent: Configuration
+nav_order: 5
+description: "Valid Minecraft material names for use in shop configuration files."
+---
+
+# 🪨 Material Names
+
+EzShops identifies every item in your shop by its **Bukkit Material name** — an uppercase, underscore-separated identifier like `DIAMOND_SWORD` or `OAK_LOG`.
+
+---
+
+## Finding Valid Material Names
+
+The authoritative source of all valid names for your server version is the **Paper/Bukkit Material enum javadoc**:
+
+- [Paper 1.21.x — `org.bukkit.Material`](https://jd.papermc.io/paper/1.21/org/bukkit/Material.html)
+
+Material names are **case-insensitive** inside EzShops config files — both `DIAMOND` and `diamond` work.
+
+---
+
+## Historical Renames
+
+Minecraft has renamed a number of items over the years. If an item suddenly stops working after a server upgrade, check the table below for a rename.
+
+| Old Name | New Name | Since Version | Notes |
+|---|---|---|---|
+| `LOG` | `OAK_LOG`, `BIRCH_LOG`, `SPRUCE_LOG`, `JUNGLE_LOG`, `ACACIA_LOG`, `DARK_OAK_LOG` | 1.13 "The Flattening" | One meta-value block became six separate materials |
+| `LOG_2` | `ACACIA_LOG`, `DARK_OAK_LOG` | 1.13 | Same flattening event |
+| `WOOD` | `OAK_PLANKS`, `BIRCH_PLANKS`, etc. | 1.13 | Old `WOOD` meta ID → individual plank names |
+| `GRASS` | `SHORT_GRASS` | 1.20.3 (Dec 2023) | Disambiguated from the grass block (`GRASS_BLOCK`) |
+| `CHAIN` | `IRON_CHAIN` | 1.21.9 "The Copper Age" (Sep 2025) | Renamed when copper chain variants were added |
+
+> **Tip:** If you have old configs with `CHAIN`, update them to `IRON_CHAIN` for 1.21.9+ servers.
+
+---
+
+## New Materials by Version
+
+Use this section when adding newly released items to your shop. All names listed match the Bukkit/Paper Material enum for the given version.
+
+### 1.21.4 — The Garden Awakens (December 3, 2024)
+
+**Pale Oak wood set:**
+`PALE_OAK_LOG`, `STRIPPED_PALE_OAK_LOG`, `PALE_OAK_WOOD`, `STRIPPED_PALE_OAK_WOOD`,
+`PALE_OAK_PLANKS`, `PALE_OAK_STAIRS`, `PALE_OAK_SLAB`, `PALE_OAK_SIGN`,
+`PALE_OAK_HANGING_SIGN`, `PALE_OAK_BUTTON`, `PALE_OAK_PRESSURE_PLATE`,
+`PALE_OAK_DOOR`, `PALE_OAK_TRAPDOOR`, `PALE_OAK_FENCE`, `PALE_OAK_FENCE_GATE`,
+`PALE_OAK_BOAT`, `PALE_OAK_CHEST_BOAT`, `PALE_OAK_LEAVES`, `PALE_OAK_SAPLING`
+
+**Pale Moss & Eyeblossoms:**
+`PALE_HANGING_MOSS`, `PALE_MOSS_BLOCK`, `PALE_MOSS_CARPET`,
+`OPEN_EYEBLOSSOM`, `CLOSED_EYEBLOSSOM`
+
+**Resin:**
+`RESIN_CLUMP`, `RESIN_BLOCK`, `RESIN_BRICK`, `RESIN_BRICKS`,
+`CHISELED_RESIN_BRICKS`, `RESIN_BRICK_SLAB`, `RESIN_BRICK_STAIRS`, `RESIN_BRICK_WALL`
+
+**Other:**
+`CREAKING_HEART`
+
+---
+
+### 1.21.5 — Spring to Life (March 25, 2025)
+
+`LEAF_LITTER`, `WILDFLOWERS`, `BUSH`, `FIREFLY_BUSH`, `CACTUS_FLOWER`,
+`SHORT_DRY_GRASS`, `TALL_DRY_GRASS`, `BLUE_EGG`, `BROWN_EGG`
+
+---
+
+### 1.21.6 — Chase the Skies (June 17, 2025)
+
+**Dried Ghast block/item:**
+`DRIED_GHAST`
+
+**Harnesses (16 dye variants):**
+`WHITE_HARNESS`, `LIGHT_GRAY_HARNESS`, `GRAY_HARNESS`, `BLACK_HARNESS`,
+`BROWN_HARNESS`, `RED_HARNESS`, `ORANGE_HARNESS`, `YELLOW_HARNESS`,
+`GREEN_HARNESS`, `LIME_HARNESS`, `CYAN_HARNESS`, `LIGHT_BLUE_HARNESS`,
+`BLUE_HARNESS`, `MAGENTA_HARNESS`, `PURPLE_HARNESS`, `PINK_HARNESS`
+
+**Spawn egg & music disc:**
+`HAPPY_GHAST_SPAWN_EGG`, `MUSIC_DISC_TEARS`
+
+---
+
+### 1.21.7 (June 30, 2025)
+
+Minor hotfix — no new blocks, items, or material renames.
+
+---
+
+### 1.21.8 (July 17, 2025)
+
+Minor hotfix — no new blocks, items, or material renames.
+
+---
+
+### 1.21.9 — The Copper Age (September 30, 2025)
+
+> ⚠️ **Breaking rename:** `CHAIN` → `IRON_CHAIN`
+
+**Copper chests (8 variants — base + 3 oxidation stages + 4 waxed variants):**
+`COPPER_CHEST`, `EXPOSED_COPPER_CHEST`, `WEATHERED_COPPER_CHEST`, `OXIDIZED_COPPER_CHEST`,
+`WAXED_COPPER_CHEST`, `WAXED_EXPOSED_COPPER_CHEST`, `WAXED_WEATHERED_COPPER_CHEST`, `WAXED_OXIDIZED_COPPER_CHEST`
+
+**Shelves (one per wood type):**
+`OAK_SHELF`, `BIRCH_SHELF`, `SPRUCE_SHELF`, `JUNGLE_SHELF`, `ACACIA_SHELF`,
+`DARK_OAK_SHELF`, `CRIMSON_SHELF`, `WARPED_SHELF`, `MANGROVE_SHELF`,
+`BAMBOO_SHELF`, `CHERRY_SHELF`, `PALE_OAK_SHELF`
+
+**Copper golem statues (8 variants):**
+`COPPER_GOLEM_STATUE`, `EXPOSED_COPPER_GOLEM_STATUE`, `WEATHERED_COPPER_GOLEM_STATUE`, `OXIDIZED_COPPER_GOLEM_STATUE`,
+`WAXED_COPPER_GOLEM_STATUE`, `WAXED_EXPOSED_COPPER_GOLEM_STATUE`, `WAXED_WEATHERED_COPPER_GOLEM_STATUE`, `WAXED_OXIDIZED_COPPER_GOLEM_STATUE`
+
+**Copper bars (8 variants):**
+`COPPER_BARS`, `EXPOSED_COPPER_BARS`, `WEATHERED_COPPER_BARS`, `OXIDIZED_COPPER_BARS`,
+`WAXED_COPPER_BARS`, `WAXED_EXPOSED_COPPER_BARS`, `WAXED_WEATHERED_COPPER_BARS`, `WAXED_OXIDIZED_COPPER_BARS`
+
+**Copper chains (8 variants):**
+`COPPER_CHAIN`, `EXPOSED_COPPER_CHAIN`, `WEATHERED_COPPER_CHAIN`, `OXIDIZED_COPPER_CHAIN`,
+`WAXED_COPPER_CHAIN`, `WAXED_EXPOSED_COPPER_CHAIN`, `WAXED_WEATHERED_COPPER_CHAIN`, `WAXED_OXIDIZED_COPPER_CHAIN`
+
+**Copper torches & lanterns:**
+`COPPER_TORCH`,
+`COPPER_LANTERN`, `EXPOSED_COPPER_LANTERN`, `WEATHERED_COPPER_LANTERN`, `OXIDIZED_COPPER_LANTERN`,
+`WAXED_COPPER_LANTERN`, `WAXED_EXPOSED_COPPER_LANTERN`, `WAXED_WEATHERED_COPPER_LANTERN`, `WAXED_OXIDIZED_COPPER_LANTERN`
+
+**Lightning rod oxidation variants (7 new):**
+`EXPOSED_LIGHTNING_ROD`, `WEATHERED_LIGHTNING_ROD`, `OXIDIZED_LIGHTNING_ROD`,
+`WAXED_LIGHTNING_ROD`, `WAXED_EXPOSED_LIGHTNING_ROD`, `WAXED_WEATHERED_LIGHTNING_ROD`, `WAXED_OXIDIZED_LIGHTNING_ROD`
+
+**Copper tools:**
+`COPPER_SWORD`, `COPPER_AXE`, `COPPER_PICKAXE`, `COPPER_SHOVEL`, `COPPER_HOE`
+
+**Copper armor:**
+`COPPER_HELMET`, `COPPER_CHESTPLATE`, `COPPER_LEGGINGS`, `COPPER_BOOTS`
+
+**Other items:**
+`COPPER_HORSE_ARMOR`, `COPPER_NUGGET`, `COPPER_GOLEM_SPAWN_EGG`
+
+---
+
+### 1.21.10 (October 7, 2025)
+
+Minor hotfix — no new blocks, items, or material renames.
+
+---
+
+### 1.21.11 — Mounts of Mayhem (December 9, 2025)
+
+**Spears:**
+`WOODEN_SPEAR`, `STONE_SPEAR`, `COPPER_SPEAR`, `IRON_SPEAR`,
+`GOLDEN_SPEAR`, `DIAMOND_SPEAR`, `NETHERITE_SPEAR`
+
+**Nautilus armor:**
+`COPPER_NAUTILUS_ARMOR`, `IRON_NAUTILUS_ARMOR`, `GOLDEN_NAUTILUS_ARMOR`,
+`DIAMOND_NAUTILUS_ARMOR`, `NETHERITE_NAUTILUS_ARMOR`
+
+**Other equipment:**
+`NETHERITE_HORSE_ARMOR`
+
+**Spawn eggs:**
+`NAUTILUS_SPAWN_EGG`, `ZOMBIE_NAUTILUS_SPAWN_EGG`,
+`CAMEL_HUSK_SPAWN_EGG`, `PARCHED_SPAWN_EGG`
+
+---
+
+### 26.1 — Tiny Takeover (March 24, 2026)
+
+> **Note:** Starting with this version, Minecraft Java Edition switched from `1.x` versioning to `26.x` (year-based). No material renames occurred with this version change.
+
+`GOLDEN_DANDELION`
+
+---
+
+### 26.1.2 (April 9, 2026)
+
+Minor hotfix — no new blocks, items, or material renames.
+
+---
+
+## Version Numbers and Material Names
+
+Mojang switched from `1.x` versioning to year-based versioning (e.g. `26.1`) starting in early 2026. **This version scheme change did not cause any material renames.** Material names only change when Mojang explicitly renames an item, which happens rarely and is documented in the table above.

--- a/docs/configuration/shop-items.md
+++ b/docs/configuration/shop-items.md
@@ -47,7 +47,7 @@ The specific slot position in the category GUI where this item will appear.
 
 ### Material (`material`)
 **Type:** `string`
-The valid Minecraft Material name (e.g., `DIAMOND_SWORD`, `STONE`).
+The valid Minecraft Material name (e.g., `DIAMOND_SWORD`, `STONE`). Names are **case-insensitive**. See [Material Names](material-names.md) for a full reference, including a list of historical renames and new materials added in each version.
 
 ### Display Name (`display-name`)
 **Type:** `string`

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.skyblockexp</groupId>
     <artifactId>ezshops</artifactId>
-    <version>2.5.4</version>
+    <version>2.5.5</version>
     <name>EzShops Plugin</name>
     <description>Standalone plugin providing the Skyblock shop command and sign shops.</description>
     <packaging>jar</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.skyblockexp</groupId>
     <artifactId>ezshops</artifactId>
-    <version>2.5.5</version>
+    <version>2.5.4</version>
     <name>EzShops Plugin</name>
     <description>Standalone plugin providing the Skyblock shop command and sign shops.</description>
     <packaging>jar</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.skyblockexp</groupId>
     <artifactId>ezshops</artifactId>
-    <version>2.5.3</version>
+    <version>2.5.4</version>
     <name>EzShops Plugin</name>
     <description>Standalone plugin providing the Skyblock shop command and sign shops.</description>
     <packaging>jar</packaging>

--- a/src/main/java/com/skyblockexp/ezshops/EzShopsPlugin.java
+++ b/src/main/java/com/skyblockexp/ezshops/EzShopsPlugin.java
@@ -13,9 +13,9 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.ListIterator;
-import java.util.logging.Level;
 import net.milkbowl.vault.economy.Economy;
 import org.bukkit.plugin.RegisteredServiceProvider;
+import java.util.logging.Level;
 import org.bukkit.plugin.java.JavaPlugin;
 
 /**

--- a/src/main/java/com/skyblockexp/ezshops/gui/quicksell/QuickSellMenu.java
+++ b/src/main/java/com/skyblockexp/ezshops/gui/quicksell/QuickSellMenu.java
@@ -365,11 +365,14 @@ public class QuickSellMenu implements Listener {
     private void handleConfirm(Player player, Inventory topInv) {
         double total = 0.0;
         boolean soldAnything = false;
+        boolean hadItems = false;
+        String lastFailureMessage = null;
 
         for (int slot = 0; slot < ITEM_SLOT_COUNT; slot++) {
             ItemStack item = topInv.getItem(slot);
             if (item == null || item.getType() == Material.AIR) continue;
 
+            hadItems = true;
             // Items in the GUI are no longer in the player's inventory, so use sellDirect which
             // skips the countMaterial / removeItems check on the player's own inventory.
             ShopTransactionResult result = transactionService.sellDirect(player, item.getType(), item.getAmount());
@@ -379,12 +382,21 @@ public class QuickSellMenu implements Listener {
                 total += pricingManager.estimateBulkTotal(
                         item.getType().name(), item.getAmount(), ShopTransactionType.SELL);
                 soldAnything = true;
+            } else {
+                lastFailureMessage = result.message();
+                // Failed items remain in the slot; onInventoryClose will return them
             }
-            // Failed items remain in the slot; onInventoryClose will return them
         }
 
         if (!soldAnything) {
-            player.sendMessage(ChatColor.translateAlternateColorCodes('&', messages.nothingToSell()));
+            // If items were present but every sellDirect call failed (e.g. economy down,
+            // dynamic price driven to $0.00 after a previous sale, rotation expired), show
+            // the actual failure reason instead of the misleading "No items to sell." message.
+            if (hadItems && lastFailureMessage != null) {
+                player.sendMessage(ChatColor.translateAlternateColorCodes('&', lastFailureMessage));
+            } else {
+                player.sendMessage(ChatColor.translateAlternateColorCodes('&', messages.nothingToSell()));
+            }
             return;
         }
 

--- a/src/main/java/com/skyblockexp/ezshops/gui/quicksell/QuickSellMenu.java
+++ b/src/main/java/com/skyblockexp/ezshops/gui/quicksell/QuickSellMenu.java
@@ -461,15 +461,12 @@ public class QuickSellMenu implements Listener {
     }
 
     /**
-     * Returns {@code true} if the material has a configured sell price and is
-     * currently available (visible / not rotation-hidden).
+     * Returns {@code true} if the material has a configured sell price.
+     * The Quick Sell GUI intentionally ignores rotation restrictions so that
+     * players can sell any item that is configured in any shop category.
      */
     private boolean isSellable(Material material) {
         if (material == null || material == Material.AIR) return false;
-        // Rotation check: if the item is part of a rotation but not currently visible, reject it
-        if (!pricingManager.isVisibleInMenu(material) && pricingManager.isPartOfRotation(material)) {
-            return false;
-        }
         return pricingManager.getPrice(material)
                 .map(ShopPrice::canSell)
                 .orElse(false);

--- a/src/main/java/com/skyblockexp/ezshops/gui/quicksell/QuickSellMenu.java
+++ b/src/main/java/com/skyblockexp/ezshops/gui/quicksell/QuickSellMenu.java
@@ -370,7 +370,9 @@ public class QuickSellMenu implements Listener {
             ItemStack item = topInv.getItem(slot);
             if (item == null || item.getType() == Material.AIR) continue;
 
-            ShopTransactionResult result = transactionService.sell(player, item.getType(), item.getAmount());
+            // Items in the GUI are no longer in the player's inventory, so use sellDirect which
+            // skips the countMaterial / removeItems check on the player's own inventory.
+            ShopTransactionResult result = transactionService.sellDirect(player, item.getType(), item.getAmount());
             if (result.success()) {
                 topInv.setItem(slot, null);
                 // Accumulate the sell value from the pricing manager for the summary

--- a/src/main/java/com/skyblockexp/ezshops/shop/ShopPricingManager.java
+++ b/src/main/java/com/skyblockexp/ezshops/shop/ShopPricingManager.java
@@ -97,6 +97,8 @@ public class ShopPricingManager {
         parseRotations(root);
         menuLayout = loadMenuLayout(root);
         cleanupDynamicState();
+        int categories = menuLayout != null ? menuLayout.categories().size() : 0;
+        logger.info("Shop configuration loaded: " + priceMap.size() + " item(s) across " + categories + " categor" + (categories == 1 ? "y" : "ies") + ".");
     }
 
     public Optional<ShopPrice> getPrice(Material material) {
@@ -325,8 +327,10 @@ public class ShopPricingManager {
 
             ShopPrice price = new ShopPrice(Double.isNaN(buyPrice) ? -1.0D : buyPrice,
                     Double.isNaN(sellPrice) ? -1.0D : sellPrice);
-            DynamicSettings dynamicSettings = parseDynamicSettings(priceSection, key);
-            registerPrice(key, price, dynamicSettings);
+            // Use the canonical material name as the price key so that getPrice(Material)
+            // can always find the entry regardless of the letter-case used in the config file.
+            DynamicSettings dynamicSettings = parseDynamicSettings(priceSection, material.name());
+            registerPrice(material.name(), price, dynamicSettings);
         }
     }
 
@@ -961,27 +965,17 @@ public class ShopPricingManager {
     }
 
     private void adjustDynamicMultiplier(Material material, int amount, boolean purchase) {
-        if (amount <= 0) {
-            return;
-        }
-        if (material == null) {
+        if (amount <= 0 || material == null) {
             return;
         }
         String nameKey = material.name();
         PriceEntry entry = priceMap.get(nameKey);
-        String foundKey = nameKey;
-        if (entry == null) {
-            // fallback: some price keys are stored using the item id (lowercase), try that too
-            String lowerKey = nameKey.toLowerCase(Locale.ENGLISH);
-            entry = priceMap.get(lowerKey);
-            foundKey = lowerKey;
-        }
         if (entry == null || !entry.hasDynamicPricing()) {
             return;
         }
         boolean changed = purchase ? entry.adjustAfterPurchase(amount) : entry.adjustAfterSale(amount);
         if (changed) {
-            saveDynamicState(foundKey, entry);
+            saveDynamicState(nameKey, entry);
         }
     }
 

--- a/src/main/java/com/skyblockexp/ezshops/shop/ShopTransactionService.java
+++ b/src/main/java/com/skyblockexp/ezshops/shop/ShopTransactionService.java
@@ -300,6 +300,57 @@ public class ShopTransactionService {
         return result;
     }
 
+    /**
+     * Sells {@code amount} of {@code material} on behalf of {@code player} without checking or removing
+     * items from the player's own inventory. Use this when the items have already been removed from an
+     * external inventory (e.g. the Quick Sell GUI) before calling this method.
+     */
+    public ShopTransactionResult sellDirect(Player player, Material material, int amount) {
+        if (economy == null) {
+            return ShopTransactionResult.failure(errorMessages.noEconomy());
+        }
+
+        if (!player.hasPermission(PERMISSION_SELL)) {
+            return ShopTransactionResult.failure(errorMessages.noSellPermission());
+        }
+
+        if (amount <= 0) {
+            return ShopTransactionResult.failure(errorMessages.amountPositive());
+        }
+
+        if (!pricingManager.isVisibleInMenu(material) && pricingManager.isPartOfRotation(material)) {
+            return ShopTransactionResult.failure(errorMessages.notInRotation());
+        }
+
+        ShopPrice price = pricingManager.getPrice(material).orElse(null);
+        if (price == null) {
+            return ShopTransactionResult.failure(errorMessages.notConfigured());
+        }
+
+        if (!price.canSell()) {
+            return ShopTransactionResult.failure(errorMessages.notSellable());
+        }
+
+        double totalGain = pricingManager.estimateBulkTotal(material, amount, com.skyblockexp.ezshops.gui.shop.ShopTransactionType.SELL);
+        totalGain = EconomyUtils.normalizeCurrency(totalGain);
+        totalGain *= getSellPriceMultiplier(player);
+        totalGain *= getTeamSellMultiplier(player);
+        if (totalGain <= 0) {
+            return ShopTransactionResult.failure(errorMessages.invalidSellPrice());
+        }
+
+        // Items are already outside the player's inventory — skip countMaterial / removeItems.
+        EconomyResponse response = economy.depositPlayer(player, totalGain);
+        if (!response.transactionSuccess()) {
+            return ShopTransactionResult.failure(errorMessages.transactionFailed(response.errorMessage));
+        }
+
+        pricingManager.handleSale(material, amount);
+        doTreasurySplit(player, totalGain);
+        return ShopTransactionResult.success(successMessages.sale(amount,
+                ChatColor.AQUA + friendlyMaterialName(material), formatCurrency(totalGain)));
+    }
+
     public ShopTransactionResult sell(Player player, com.skyblockexp.ezshops.shop.ShopMenuLayout.Item item, int amount) {
         if (economy == null) {
             return ShopTransactionResult.failure(errorMessages.noEconomy());

--- a/src/main/java/com/skyblockexp/ezshops/shop/ShopTransactionService.java
+++ b/src/main/java/com/skyblockexp/ezshops/shop/ShopTransactionService.java
@@ -304,6 +304,10 @@ public class ShopTransactionService {
      * Sells {@code amount} of {@code material} on behalf of {@code player} without checking or removing
      * items from the player's own inventory. Use this when the items have already been removed from an
      * external inventory (e.g. the Quick Sell GUI) before calling this method.
+     *
+     * <p>Unlike {@link #sell(Player, Material, int)}, this method does <em>not</em> apply the rotation
+     * restriction. The Quick Sell GUI accepts any item that has a configured sell price, regardless of
+     * which rotation option is currently active.</p>
      */
     public ShopTransactionResult sellDirect(Player player, Material material, int amount) {
         if (economy == null) {
@@ -316,10 +320,6 @@ public class ShopTransactionService {
 
         if (amount <= 0) {
             return ShopTransactionResult.failure(errorMessages.amountPositive());
-        }
-
-        if (!pricingManager.isVisibleInMenu(material) && pricingManager.isPartOfRotation(material)) {
-            return ShopTransactionResult.failure(errorMessages.notInRotation());
         }
 
         ShopPrice price = pricingManager.getPrice(material).orElse(null);

--- a/src/main/resources/shop/categories/building.yml
+++ b/src/main/resources/shop/categories/building.yml
@@ -1,4 +1,6 @@
 # EzShops category configuration for "building".
+# For valid material names see: docs/configuration/material-names.md
+# or https://jd.papermc.io/paper/1.21/org/bukkit/Material.html
 categories:
   building:
     name: "{translate:shop.categories.building.name}"
@@ -28,10 +30,6 @@ categories:
         - "{translate:shop.common.shift-click-line}"
         buy: 64.0
         sell: 32.0
-        on-buy:
-          execute-as: console
-          commands:
-          - "broadcast test 1 2 3"
       glass:
         material: GLASS
         slot: 11

--- a/src/main/resources/shop/categories/building.yml
+++ b/src/main/resources/shop/categories/building.yml
@@ -316,3 +316,121 @@ categories:
         - "{translate:shop.common.shift-click-line}"
         buy: 56.0
         sell: 26.0
+      # --- Planks (crafted from logs; lower unit value than logs) ---
+      oak_planks:
+        material: OAK_PLANKS
+        slot: 37
+        amount: 16
+        bulk-amount: 64
+        icon-amount: 16
+        display-name: "{translate:shop.common.item-display-name}"
+        lore:
+        - "{translate:shop.common.buy-line}"
+        - "{translate:shop.common.sell-line}"
+        - "{translate:shop.common.shift-click-line}"
+        buy: 6.0
+        sell: 2.5
+      spruce_planks:
+        material: SPRUCE_PLANKS
+        slot: 38
+        amount: 16
+        bulk-amount: 64
+        icon-amount: 16
+        display-name: "{translate:shop.common.item-display-name}"
+        lore:
+        - "{translate:shop.common.buy-line}"
+        - "{translate:shop.common.sell-line}"
+        - "{translate:shop.common.shift-click-line}"
+        buy: 6.5
+        sell: 2.75
+      birch_planks:
+        material: BIRCH_PLANKS
+        slot: 39
+        amount: 16
+        bulk-amount: 64
+        icon-amount: 16
+        display-name: "{translate:shop.common.item-display-name}"
+        lore:
+        - "{translate:shop.common.buy-line}"
+        - "{translate:shop.common.sell-line}"
+        - "{translate:shop.common.shift-click-line}"
+        buy: 6.5
+        sell: 2.75
+      jungle_planks:
+        material: JUNGLE_PLANKS
+        slot: 40
+        amount: 16
+        bulk-amount: 64
+        icon-amount: 16
+        display-name: "{translate:shop.common.item-display-name}"
+        lore:
+        - "{translate:shop.common.buy-line}"
+        - "{translate:shop.common.sell-line}"
+        - "{translate:shop.common.shift-click-line}"
+        buy: 7.0
+        sell: 3.0
+      acacia_planks:
+        material: ACACIA_PLANKS
+        slot: 41
+        amount: 16
+        bulk-amount: 64
+        icon-amount: 16
+        display-name: "{translate:shop.common.item-display-name}"
+        lore:
+        - "{translate:shop.common.buy-line}"
+        - "{translate:shop.common.sell-line}"
+        - "{translate:shop.common.shift-click-line}"
+        buy: 7.0
+        sell: 3.0
+      dark_oak_planks:
+        material: DARK_OAK_PLANKS
+        slot: 42
+        amount: 16
+        bulk-amount: 64
+        icon-amount: 16
+        display-name: "{translate:shop.common.item-display-name}"
+        lore:
+        - "{translate:shop.common.buy-line}"
+        - "{translate:shop.common.sell-line}"
+        - "{translate:shop.common.shift-click-line}"
+        buy: 7.0
+        sell: 3.0
+      mangrove_planks:
+        material: MANGROVE_PLANKS
+        slot: 43
+        amount: 16
+        bulk-amount: 64
+        icon-amount: 16
+        display-name: "{translate:shop.common.item-display-name}"
+        lore:
+        - "{translate:shop.common.buy-line}"
+        - "{translate:shop.common.sell-line}"
+        - "{translate:shop.common.shift-click-line}"
+        buy: 7.0
+        sell: 3.0
+      pale_oak_planks:
+        material: PALE_OAK_PLANKS
+        slot: 44
+        amount: 16
+        bulk-amount: 64
+        icon-amount: 16
+        display-name: "{translate:shop.common.item-display-name}"
+        lore:
+        - "{translate:shop.common.buy-line}"
+        - "{translate:shop.common.sell-line}"
+        - "{translate:shop.common.shift-click-line}"
+        buy: 8.0
+        sell: 3.5
+      cherry_planks:
+        material: CHERRY_PLANKS
+        slot: 46
+        amount: 16
+        bulk-amount: 64
+        icon-amount: 16
+        display-name: "{translate:shop.common.item-display-name}"
+        lore:
+        - "{translate:shop.common.buy-line}"
+        - "{translate:shop.common.sell-line}"
+        - "{translate:shop.common.shift-click-line}"
+        buy: 7.5
+        sell: 3.25

--- a/src/main/resources/shop/categories/daily_specials.yml
+++ b/src/main/resources/shop/categories/daily_specials.yml
@@ -1,4 +1,6 @@
 # Example category wired to the bundled daily-specials rotation group.
+# For valid material names see: docs/configuration/material-names.md
+# or https://jd.papermc.io/paper/1.21/org/bukkit/Material.html
 #
 # Any category can opt into a rotation by setting rotation-group to the ID from
 # shop/rotations/*.yml. The menu pulls shared defaults from rotation-defaults

--- a/src/main/resources/shop/categories/decorations.yml
+++ b/src/main/resources/shop/categories/decorations.yml
@@ -1,4 +1,6 @@
 # EzShops category configuration for "decorations".
+# For valid material names see: docs/configuration/material-names.md
+# or https://jd.papermc.io/paper/1.21/org/bukkit/Material.html
 categories:
   decorations:
     name: "{translate:shop.categories.decorations.name}"

--- a/src/main/resources/shop/categories/enchantments.yml
+++ b/src/main/resources/shop/categories/enchantments.yml
@@ -1,4 +1,6 @@
 # EzShops category configuration for "enchantments".
+# For valid material names see: docs/configuration/material-names.md
+# or https://jd.papermc.io/paper/1.21/org/bukkit/Material.html
 categories:
   enchantments:
     name: "{translate:shop.categories.enchantments.name}"

--- a/src/main/resources/shop/categories/farming.yml
+++ b/src/main/resources/shop/categories/farming.yml
@@ -1,4 +1,6 @@
 # EzShops category configuration for "farming".
+# For valid material names see: docs/configuration/material-names.md
+# or https://jd.papermc.io/paper/1.21/org/bukkit/Material.html
 categories:
   farming:
     name: "{translate:shop.categories.farming.name}"

--- a/src/main/resources/shop/categories/fishing.yml
+++ b/src/main/resources/shop/categories/fishing.yml
@@ -1,4 +1,6 @@
 # EzShops category configuration for "fishing".
+# For valid material names see: docs/configuration/material-names.md
+# or https://jd.papermc.io/paper/1.21/org/bukkit/Material.html
 categories:
   fishing:
     name: "{translate:shop.categories.fishing.name}"

--- a/src/main/resources/shop/categories/food.yml
+++ b/src/main/resources/shop/categories/food.yml
@@ -1,4 +1,6 @@
 # EzShops category configuration for "food".
+# For valid material names see: docs/configuration/material-names.md
+# or https://jd.papermc.io/paper/1.21/org/bukkit/Material.html
 categories:
   food:
     name: "{translate:shop.categories.food.name}"

--- a/src/main/resources/shop/categories/mining.yml
+++ b/src/main/resources/shop/categories/mining.yml
@@ -1,4 +1,6 @@
 # EzShops category configuration for "mining".
+# For valid material names see: docs/configuration/material-names.md
+# or https://jd.papermc.io/paper/1.21/org/bukkit/Material.html
 categories:
   mining:
     name: "{translate:shop.categories.mining.name}"

--- a/src/main/resources/shop/categories/mob_drops.yml
+++ b/src/main/resources/shop/categories/mob_drops.yml
@@ -1,4 +1,6 @@
 # EzShops category configuration for "mob_drops".
+# For valid material names see: docs/configuration/material-names.md
+# or https://jd.papermc.io/paper/1.21/org/bukkit/Material.html
 categories:
   mob_drops:
     name: "{translate:shop.categories.mob_drops.name}"

--- a/src/main/resources/shop/categories/redstone.yml
+++ b/src/main/resources/shop/categories/redstone.yml
@@ -1,4 +1,6 @@
 # EzShops category configuration for "redstone".
+# For valid material names see: docs/configuration/material-names.md
+# or https://jd.papermc.io/paper/1.21/org/bukkit/Material.html
 categories:
   redstone:
     name: "{translate:shop.categories.redstone.name}"

--- a/src/main/resources/shop/categories/spawners.yml
+++ b/src/main/resources/shop/categories/spawners.yml
@@ -1,4 +1,6 @@
 # EzShops category configuration for "spawners".
+# For valid material names see: docs/configuration/material-names.md
+# or https://jd.papermc.io/paper/1.21/org/bukkit/Material.html
 categories:
   spawners:
     name: "{translate:shop.categories.spawners.name}"

--- a/src/main/resources/shop/categories/valuables.yml
+++ b/src/main/resources/shop/categories/valuables.yml
@@ -1,4 +1,6 @@
 # EzShops category configuration for "valuables".
+# For valid material names see: docs/configuration/material-names.md
+# or https://jd.papermc.io/paper/1.21/org/bukkit/Material.html
 categories:
   valuables:
     name: "{translate:shop.categories.valuables.name}"

--- a/src/main/resources/shop/categories/wood.yml
+++ b/src/main/resources/shop/categories/wood.yml
@@ -134,3 +134,121 @@ categories:
         - "{translate:shop.common.shift-click-line}"
         buy: 30.0
         sell: 13.0
+      # --- Stripped logs (bark removed; slightly lower value than full logs) ---
+      stripped_oak_log:
+        material: STRIPPED_OAK_LOG
+        slot: 20
+        amount: 16
+        bulk-amount: 64
+        icon-amount: 16
+        display-name: "{translate:shop.common.item-display-name}"
+        lore:
+        - "{translate:shop.common.buy-line}"
+        - "{translate:shop.common.sell-line}"
+        - "{translate:shop.common.shift-click-line}"
+        buy: 19.0
+        sell: 8.0
+      stripped_spruce_log:
+        material: STRIPPED_SPRUCE_LOG
+        slot: 21
+        amount: 16
+        bulk-amount: 64
+        icon-amount: 16
+        display-name: "{translate:shop.common.item-display-name}"
+        lore:
+        - "{translate:shop.common.buy-line}"
+        - "{translate:shop.common.sell-line}"
+        - "{translate:shop.common.shift-click-line}"
+        buy: 21.0
+        sell: 9.0
+      stripped_birch_log:
+        material: STRIPPED_BIRCH_LOG
+        slot: 22
+        amount: 16
+        bulk-amount: 64
+        icon-amount: 16
+        display-name: "{translate:shop.common.item-display-name}"
+        lore:
+        - "{translate:shop.common.buy-line}"
+        - "{translate:shop.common.sell-line}"
+        - "{translate:shop.common.shift-click-line}"
+        buy: 21.0
+        sell: 9.0
+      stripped_jungle_log:
+        material: STRIPPED_JUNGLE_LOG
+        slot: 23
+        amount: 16
+        bulk-amount: 64
+        icon-amount: 16
+        display-name: "{translate:shop.common.item-display-name}"
+        lore:
+        - "{translate:shop.common.buy-line}"
+        - "{translate:shop.common.sell-line}"
+        - "{translate:shop.common.shift-click-line}"
+        buy: 22.0
+        sell: 9.5
+      stripped_acacia_log:
+        material: STRIPPED_ACACIA_LOG
+        slot: 24
+        amount: 16
+        bulk-amount: 64
+        icon-amount: 16
+        display-name: "{translate:shop.common.item-display-name}"
+        lore:
+        - "{translate:shop.common.buy-line}"
+        - "{translate:shop.common.sell-line}"
+        - "{translate:shop.common.shift-click-line}"
+        buy: 22.0
+        sell: 9.5
+      stripped_dark_oak_log:
+        material: STRIPPED_DARK_OAK_LOG
+        slot: 25
+        amount: 16
+        bulk-amount: 64
+        icon-amount: 16
+        display-name: "{translate:shop.common.item-display-name}"
+        lore:
+        - "{translate:shop.common.buy-line}"
+        - "{translate:shop.common.sell-line}"
+        - "{translate:shop.common.shift-click-line}"
+        buy: 22.0
+        sell: 9.5
+      stripped_mangrove_log:
+        material: STRIPPED_MANGROVE_LOG
+        slot: 26
+        amount: 16
+        bulk-amount: 64
+        icon-amount: 16
+        display-name: "{translate:shop.common.item-display-name}"
+        lore:
+        - "{translate:shop.common.buy-line}"
+        - "{translate:shop.common.sell-line}"
+        - "{translate:shop.common.shift-click-line}"
+        buy: 22.0
+        sell: 9.5
+      stripped_pale_oak_log:
+        material: STRIPPED_PALE_OAK_LOG
+        slot: 28
+        amount: 16
+        bulk-amount: 64
+        icon-amount: 16
+        display-name: "{translate:shop.common.item-display-name}"
+        lore:
+        - "{translate:shop.common.buy-line}"
+        - "{translate:shop.common.sell-line}"
+        - "{translate:shop.common.shift-click-line}"
+        buy: 26.0
+        sell: 11.0
+      stripped_cherry_log:
+        material: STRIPPED_CHERRY_LOG
+        slot: 29
+        amount: 16
+        bulk-amount: 64
+        icon-amount: 16
+        display-name: "{translate:shop.common.item-display-name}"
+        lore:
+        - "{translate:shop.common.buy-line}"
+        - "{translate:shop.common.sell-line}"
+        - "{translate:shop.common.shift-click-line}"
+        buy: 24.0
+        sell: 10.5

--- a/src/main/resources/shop/categories/wood.yml
+++ b/src/main/resources/shop/categories/wood.yml
@@ -1,4 +1,6 @@
 # EzShops category configuration for "wood".
+# For valid material names see: docs/configuration/material-names.md
+# or https://jd.papermc.io/paper/1.21/org/bukkit/Material.html
 categories:
   wood:
     name: "{translate:shop.categories.wood.name}"

--- a/src/main/resources/shop/categories/wood.yml
+++ b/src/main/resources/shop/categories/wood.yml
@@ -252,3 +252,121 @@ categories:
         - "{translate:shop.common.shift-click-line}"
         buy: 24.0
         sell: 10.5
+      # --- Wood blocks (all-bark logs; same value as the equivalent log) ---
+      oak_wood:
+        material: OAK_WOOD
+        slot: 37
+        amount: 16
+        bulk-amount: 64
+        icon-amount: 16
+        display-name: "{translate:shop.common.item-display-name}"
+        lore:
+        - "{translate:shop.common.buy-line}"
+        - "{translate:shop.common.sell-line}"
+        - "{translate:shop.common.shift-click-line}"
+        buy: 24.0
+        sell: 10.0
+      spruce_wood:
+        material: SPRUCE_WOOD
+        slot: 38
+        amount: 16
+        bulk-amount: 64
+        icon-amount: 16
+        display-name: "{translate:shop.common.item-display-name}"
+        lore:
+        - "{translate:shop.common.buy-line}"
+        - "{translate:shop.common.sell-line}"
+        - "{translate:shop.common.shift-click-line}"
+        buy: 26.0
+        sell: 11.0
+      birch_wood:
+        material: BIRCH_WOOD
+        slot: 39
+        amount: 16
+        bulk-amount: 64
+        icon-amount: 16
+        display-name: "{translate:shop.common.item-display-name}"
+        lore:
+        - "{translate:shop.common.buy-line}"
+        - "{translate:shop.common.sell-line}"
+        - "{translate:shop.common.shift-click-line}"
+        buy: 26.0
+        sell: 11.0
+      jungle_wood:
+        material: JUNGLE_WOOD
+        slot: 40
+        amount: 16
+        bulk-amount: 64
+        icon-amount: 16
+        display-name: "{translate:shop.common.item-display-name}"
+        lore:
+        - "{translate:shop.common.buy-line}"
+        - "{translate:shop.common.sell-line}"
+        - "{translate:shop.common.shift-click-line}"
+        buy: 27.0
+        sell: 11.5
+      acacia_wood:
+        material: ACACIA_WOOD
+        slot: 41
+        amount: 16
+        bulk-amount: 64
+        icon-amount: 16
+        display-name: "{translate:shop.common.item-display-name}"
+        lore:
+        - "{translate:shop.common.buy-line}"
+        - "{translate:shop.common.sell-line}"
+        - "{translate:shop.common.shift-click-line}"
+        buy: 27.0
+        sell: 11.5
+      dark_oak_wood:
+        material: DARK_OAK_WOOD
+        slot: 42
+        amount: 16
+        bulk-amount: 64
+        icon-amount: 16
+        display-name: "{translate:shop.common.item-display-name}"
+        lore:
+        - "{translate:shop.common.buy-line}"
+        - "{translate:shop.common.sell-line}"
+        - "{translate:shop.common.shift-click-line}"
+        buy: 28.0
+        sell: 12.0
+      mangrove_wood:
+        material: MANGROVE_WOOD
+        slot: 43
+        amount: 16
+        bulk-amount: 64
+        icon-amount: 16
+        display-name: "{translate:shop.common.item-display-name}"
+        lore:
+        - "{translate:shop.common.buy-line}"
+        - "{translate:shop.common.sell-line}"
+        - "{translate:shop.common.shift-click-line}"
+        buy: 28.0
+        sell: 12.0
+      pale_oak_wood:
+        material: PALE_OAK_WOOD
+        slot: 44
+        amount: 16
+        bulk-amount: 64
+        icon-amount: 16
+        display-name: "{translate:shop.common.item-display-name}"
+        lore:
+        - "{translate:shop.common.buy-line}"
+        - "{translate:shop.common.sell-line}"
+        - "{translate:shop.common.shift-click-line}"
+        buy: 32.0
+        sell: 13.5
+      cherry_wood:
+        material: CHERRY_WOOD
+        slot: 46
+        amount: 16
+        bulk-amount: 64
+        icon-amount: 16
+        display-name: "{translate:shop.common.item-display-name}"
+        lore:
+        - "{translate:shop.common.buy-line}"
+        - "{translate:shop.common.sell-line}"
+        - "{translate:shop.common.shift-click-line}"
+        buy: 30.0
+        sell: 13.0

--- a/src/test/java/com/skyblockexp/ezshops/gui/QuickSellMenuShiftClickTest.java
+++ b/src/test/java/com/skyblockexp/ezshops/gui/QuickSellMenuShiftClickTest.java
@@ -102,6 +102,66 @@ public class QuickSellMenuShiftClickTest extends AbstractEzShopsTest {
         assertTrue(slot5 == null || slot5.getType() == Material.AIR, "Slot 5 should be empty");
     }
 
+    /**
+     * When items ARE present in the GUI but sellDirect fails for a real reason (e.g. the economy
+     * rejects the deposit), handleConfirm must show the actual failure reason, not the misleading
+     * "No items to sell." message.
+     *
+     * <p>This is a regression test for the secondary symptom of GitHub issue
+     * "sell GUI sometimes fails to detect items added with shift-click":
+     * after a first successful sale drives dynamic pricing down to $0, the second
+     * attempt returns an invalidSellPrice failure and the player would incorrectly
+     * see "Nothing to sell" even though items are clearly visible in the GUI.
+     */
+    @Test
+    void confirm_shows_sell_failure_reason_not_nothing_to_sell_when_economy_rejects_deposit() throws Exception {
+        Economy econ = mock(Economy.class);
+        when(econ.format(anyDouble())).thenReturn("$0.00");
+        // Economy deliberately fails — simulates the deposit being rejected
+        when(econ.depositPlayer(any(Player.class), anyDouble()))
+                .thenReturn(new EconomyResponse(0.0, 0.0, EconomyResponse.ResponseType.FAILURE, "Bank offline"));
+        loadProviderPlugin(econ);
+
+        EzShopsPlugin plugin = loadPlugin(EzShopsPlugin.class);
+        CoreShopComponent core = plugin.getCoreShopComponent();
+        assertNotNull(core);
+
+        Field quickSellField = CoreShopComponent.class.getDeclaredField("quickSellMenu");
+        quickSellField.setAccessible(true);
+        QuickSellMenu quickSellMenu = (QuickSellMenu) quickSellField.get(core);
+        assertNotNull(quickSellMenu);
+
+        Player player = server.addPlayer("economy-fail-player");
+        player.addAttachment(plugin, ShopTransactionService.PERMISSION_SELL, true);
+        quickSellMenu.open(player);
+
+        Inventory guiInv = player.getOpenInventory().getTopInventory();
+        assertNotNull(guiInv);
+
+        // Items are in the GUI only (simulates shift-click)
+        player.getInventory().remove(Material.DIAMOND);
+        guiInv.setItem(0, new ItemStack(Material.DIAMOND, 16));
+
+        Method handleConfirm = QuickSellMenu.class.getDeclaredMethod("handleConfirm", Player.class, Inventory.class);
+        handleConfirm.setAccessible(true);
+        handleConfirm.invoke(quickSellMenu, player, guiInv);
+
+        // Economy was reached — items in the GUI were found and a sell was attempted
+        verify(econ, atLeastOnce()).depositPlayer(eq(player), anyDouble());
+
+        // The item must still be in the GUI slot (sell failed → not cleared)
+        ItemStack remaining = guiInv.getItem(0);
+        assertNotNull(remaining, "GUI slot should still have the item after a failed sell");
+        assertNotEquals(Material.AIR, remaining.getType(), "GUI slot should still have the item after a failed sell");
+
+        // The player must NOT see "No items to sell." — that message is only for an actually empty GUI.
+        // The real failure reason (transaction failed) should be shown instead.
+        String message = ((org.mockbukkit.mockbukkit.entity.PlayerMock) player).nextMessage();
+        assertNotNull(message, "Player should have received an error message");
+        assertFalse(message.contains("No items to sell"),
+                "Expected the sell-failure reason to be shown, but got 'No items to sell': " + message);
+    }
+
     private static int countMaterial(Player player, Material material) {
         int count = 0;
         for (ItemStack stack : player.getInventory().getStorageContents()) {

--- a/src/test/java/com/skyblockexp/ezshops/gui/QuickSellMenuShiftClickTest.java
+++ b/src/test/java/com/skyblockexp/ezshops/gui/QuickSellMenuShiftClickTest.java
@@ -1,0 +1,114 @@
+package com.skyblockexp.ezshops.gui;
+
+import com.skyblockexp.ezshops.AbstractEzShopsTest;
+import com.skyblockexp.ezshops.EzShopsPlugin;
+import com.skyblockexp.ezshops.bootstrap.CoreShopComponent;
+import com.skyblockexp.ezshops.gui.quicksell.QuickSellMenu;
+import com.skyblockexp.ezshops.shop.ShopTransactionService;
+import net.milkbowl.vault.economy.Economy;
+import net.milkbowl.vault.economy.EconomyResponse;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+public class QuickSellMenuShiftClickTest extends AbstractEzShopsTest {
+
+    @Test
+    void confirm_sells_items_present_only_in_gui_not_in_player_inventory() throws Exception {
+        Economy econ = mock(Economy.class);
+        when(econ.format(anyDouble())).thenReturn("$0.00");
+        when(econ.depositPlayer(any(Player.class), anyDouble()))
+                .thenReturn(new EconomyResponse(0.0, 1000.0, EconomyResponse.ResponseType.SUCCESS, "ok"));
+        loadProviderPlugin(econ);
+
+        EzShopsPlugin plugin = loadPlugin(EzShopsPlugin.class);
+        assertNotNull(plugin);
+
+        CoreShopComponent core = plugin.getCoreShopComponent();
+        assertNotNull(core);
+
+        Field quickSellField = CoreShopComponent.class.getDeclaredField("quickSellMenu");
+        quickSellField.setAccessible(true);
+        QuickSellMenu quickSellMenu = (QuickSellMenu) quickSellField.get(core);
+        assertNotNull(quickSellMenu);
+
+        Player player = server.addPlayer("shift-click-player");
+        player.addAttachment(plugin, ShopTransactionService.PERMISSION_SELL, true);
+        quickSellMenu.open(player);
+
+        Inventory guiInv = player.getOpenInventory().getTopInventory();
+        assertNotNull(guiInv);
+
+        player.getInventory().remove(Material.DIAMOND);
+        assertEquals(0, countMaterial(player, Material.DIAMOND));
+
+        guiInv.setItem(0, new ItemStack(Material.DIAMOND, 16));
+
+        Method handleConfirm = QuickSellMenu.class.getDeclaredMethod("handleConfirm", Player.class, Inventory.class);
+        handleConfirm.setAccessible(true);
+        handleConfirm.invoke(quickSellMenu, player, guiInv);
+
+        verify(econ, atLeastOnce()).depositPlayer(eq(player), anyDouble());
+
+        ItemStack remaining = guiInv.getItem(0);
+        assertTrue(remaining == null || remaining.getType() == Material.AIR,
+                "GUI slot should be empty after a successful sale");
+    }
+
+    @Test
+    void confirm_sells_multiple_stacks_in_gui_at_once() throws Exception {
+        Economy econ = mock(Economy.class);
+        when(econ.format(anyDouble())).thenReturn("$0.00");
+        when(econ.depositPlayer(any(Player.class), anyDouble()))
+                .thenReturn(new EconomyResponse(0.0, 1000.0, EconomyResponse.ResponseType.SUCCESS, "ok"));
+        loadProviderPlugin(econ);
+
+        EzShopsPlugin plugin = loadPlugin(EzShopsPlugin.class);
+        assertNotNull(plugin);
+
+        CoreShopComponent core = plugin.getCoreShopComponent();
+        Field quickSellField = CoreShopComponent.class.getDeclaredField("quickSellMenu");
+        quickSellField.setAccessible(true);
+        QuickSellMenu quickSellMenu = (QuickSellMenu) quickSellField.get(core);
+        assertNotNull(quickSellMenu);
+
+        Player player = server.addPlayer("multi-stack-player");
+        player.addAttachment(plugin, ShopTransactionService.PERMISSION_SELL, true);
+        quickSellMenu.open(player);
+        Inventory guiInv = player.getOpenInventory().getTopInventory();
+
+        player.getInventory().remove(Material.DIAMOND);
+        guiInv.setItem(0, new ItemStack(Material.DIAMOND, 8));
+        guiInv.setItem(5, new ItemStack(Material.DIAMOND, 16));
+
+        Method handleConfirm = QuickSellMenu.class.getDeclaredMethod("handleConfirm", Player.class, Inventory.class);
+        handleConfirm.setAccessible(true);
+        handleConfirm.invoke(quickSellMenu, player, guiInv);
+
+        verify(econ, atLeast(2)).depositPlayer(eq(player), anyDouble());
+
+        ItemStack slot0 = guiInv.getItem(0);
+        ItemStack slot5 = guiInv.getItem(5);
+        assertTrue(slot0 == null || slot0.getType() == Material.AIR, "Slot 0 should be empty");
+        assertTrue(slot5 == null || slot5.getType() == Material.AIR, "Slot 5 should be empty");
+    }
+
+    private static int countMaterial(Player player, Material material) {
+        int count = 0;
+        for (ItemStack stack : player.getInventory().getStorageContents()) {
+            if (stack != null && stack.getType() == material) {
+                count += stack.getAmount();
+            }
+        }
+        return count;
+    }
+}

--- a/src/test/java/com/skyblockexp/ezshops/shop/SellHandCommandTest.java
+++ b/src/test/java/com/skyblockexp/ezshops/shop/SellHandCommandTest.java
@@ -1,0 +1,139 @@
+package com.skyblockexp.ezshops.shop;
+
+import com.skyblockexp.ezshops.AbstractEzShopsTest;
+import com.skyblockexp.ezshops.config.ShopMessageConfiguration;
+import com.skyblockexp.ezshops.shop.command.SellHandCommand;
+import net.milkbowl.vault.economy.Economy;
+import net.milkbowl.vault.economy.EconomyResponse;
+import org.bukkit.Material;
+import org.bukkit.command.Command;
+import org.bukkit.command.ConsoleCommandSender;
+import org.bukkit.entity.Player;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
+import org.bukkit.inventory.ItemStack;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Feature tests for {@link SellHandCommand} — the {@code /sellhand} command.
+ */
+public class SellHandCommandTest extends AbstractEzShopsTest {
+
+    private SellHandCommand buildCommand(ShopTransactionService svc, ShopPricingManager pm,
+            com.skyblockexp.ezshops.EzShopsPlugin plugin) {
+        ShopMessageConfiguration.CommandMessages.SellHandCommandMessages messages =
+                ShopMessageConfiguration.load(plugin).commands().sellHand();
+        return new SellHandCommand(svc, pm, messages);
+    }
+
+    private ShopTransactionService buildService(ShopPricingManager pm, Economy econ,
+            com.skyblockexp.ezshops.EzShopsPlugin plugin) {
+        return new ShopTransactionService(pm, econ, ShopMessageConfiguration.load(plugin).transactions());
+    }
+
+    private Command dummyCommand() {
+        Command cmd = Mockito.mock(Command.class);
+        when(cmd.getName()).thenReturn("sellhand");
+        return cmd;
+    }
+
+    @Test
+    void sellhand_sends_must_hold_item_message_when_player_holds_nothing() {
+        loadProviderPlugin(Mockito.mock(Economy.class));
+        var plugin = loadPlugin(com.skyblockexp.ezshops.EzShopsPlugin.class);
+
+        ShopPricingManager pm = Mockito.mock(ShopPricingManager.class);
+        Economy econ = Mockito.mock(Economy.class);
+        ShopTransactionService svc = buildService(pm, econ, plugin);
+        SellHandCommand cmd = buildCommand(svc, pm, plugin);
+
+        Player player = server.addPlayer("seller");
+        player.addAttachment(plugin, ShopTransactionService.PERMISSION_SELL, true);
+        // Player holds nothing (AIR by default)
+
+        cmd.onCommand(player, dummyCommand(), "sellhand", new String[]{});
+
+        String expected = ShopMessageConfiguration.load(plugin).commands().sellHand().mustHoldItem();
+        assertEquals(expected, ((PlayerMock) player).nextMessage(), "Player should receive must-hold-item message");
+        verify(econ, never()).depositPlayer((org.bukkit.OfflinePlayer) any(), anyDouble());
+    }
+
+    @Test
+    void sellhand_succeeds_when_player_holds_a_configured_sellable_item() {
+        loadProviderPlugin(Mockito.mock(Economy.class));
+        var plugin = loadPlugin(com.skyblockexp.ezshops.EzShopsPlugin.class);
+
+        ShopPricingManager pm = Mockito.mock(ShopPricingManager.class);
+        ShopPrice price = new ShopPrice(10.0, 5.0);
+        when(pm.getPrice(eq(Material.DIAMOND))).thenReturn(Optional.of(price));
+        when(pm.estimateBulkTotal(eq(Material.DIAMOND), eq(16), any())).thenReturn(80.0);
+        when(pm.isVisibleInMenu(Material.DIAMOND)).thenReturn(true);
+
+        Economy econ = Mockito.mock(Economy.class);
+        when(econ.depositPlayer((org.bukkit.OfflinePlayer) any(), anyDouble()))
+                .thenReturn(new EconomyResponse(0.0, 1000.0, EconomyResponse.ResponseType.SUCCESS, "ok"));
+        when(econ.format(anyDouble())).thenReturn("$80.00");
+
+        ShopTransactionService svc = buildService(pm, econ, plugin);
+        SellHandCommand cmd = buildCommand(svc, pm, plugin);
+
+        Player player = server.addPlayer("seller");
+        player.addAttachment(plugin, ShopTransactionService.PERMISSION_SELL, true);
+        // Add items to both hand and inventory so sell(Material) count check passes
+        player.getInventory().addItem(new ItemStack(Material.DIAMOND, 16));
+        player.getInventory().setItemInMainHand(new ItemStack(Material.DIAMOND, 16));
+
+        cmd.onCommand(player, dummyCommand(), "sellhand", new String[]{});
+
+        verify(econ).depositPlayer((org.bukkit.OfflinePlayer) any(), eq(80.0));
+    }
+
+    @Test
+    void sellhand_sends_not_in_rotation_message_when_rotation_blocks_held_item() {
+        loadProviderPlugin(Mockito.mock(Economy.class));
+        var plugin = loadPlugin(com.skyblockexp.ezshops.EzShopsPlugin.class);
+
+        ShopPricingManager pm = Mockito.mock(ShopPricingManager.class);
+        when(pm.isVisibleInMenu(Material.DIAMOND)).thenReturn(false);
+        when(pm.isPartOfRotation(Material.DIAMOND)).thenReturn(true);
+
+        Economy econ = Mockito.mock(Economy.class);
+        ShopTransactionService svc = buildService(pm, econ, plugin);
+        SellHandCommand cmd = buildCommand(svc, pm, plugin);
+
+        Player player = server.addPlayer("seller");
+        player.addAttachment(plugin, ShopTransactionService.PERMISSION_SELL, true);
+        player.getInventory().setItemInMainHand(new ItemStack(Material.DIAMOND, 1));
+
+        cmd.onCommand(player, dummyCommand(), "sellhand", new String[]{});
+
+        // The SellHandCommand itself checks rotation before calling transactionService
+        String expected = ShopMessageConfiguration.load(plugin).commands().sellHand().notInRotation();
+        assertEquals(expected, ((PlayerMock) player).nextMessage());
+        verify(econ, never()).depositPlayer((org.bukkit.OfflinePlayer) any(), anyDouble());
+    }
+
+    @Test
+    void sellhand_sends_players_only_message_when_sender_is_console() {
+        loadProviderPlugin(Mockito.mock(Economy.class));
+        var plugin = loadPlugin(com.skyblockexp.ezshops.EzShopsPlugin.class);
+
+        ShopPricingManager pm = Mockito.mock(ShopPricingManager.class);
+        Economy econ = Mockito.mock(Economy.class);
+        ShopTransactionService svc = buildService(pm, econ, plugin);
+        SellHandCommand cmd = buildCommand(svc, pm, plugin);
+
+        ConsoleCommandSender console = server.getConsoleSender();
+
+        cmd.onCommand(console, dummyCommand(), "sellhand", new String[]{});
+
+        // ConsoleCommandSender is not a Player — command should reply and not call economy
+        verify(econ, never()).depositPlayer((org.bukkit.OfflinePlayer) any(), anyDouble());
+    }
+}

--- a/src/test/java/com/skyblockexp/ezshops/shop/ShopSellInventoryTest.java
+++ b/src/test/java/com/skyblockexp/ezshops/shop/ShopSellInventoryTest.java
@@ -1,0 +1,199 @@
+package com.skyblockexp.ezshops.shop;
+
+import com.skyblockexp.ezshops.AbstractEzShopsTest;
+import com.skyblockexp.ezshops.config.ShopMessageConfiguration;
+import net.milkbowl.vault.economy.Economy;
+import net.milkbowl.vault.economy.EconomyResponse;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Feature tests for {@link ShopTransactionService#sellInventory(Player)}.
+ */
+public class ShopSellInventoryTest extends AbstractEzShopsTest {
+
+    private ShopTransactionService buildService(ShopPricingManager pricingManager, Economy economy,
+            com.skyblockexp.ezshops.EzShopsPlugin plugin) {
+        return new ShopTransactionService(pricingManager, economy,
+                ShopMessageConfiguration.load(plugin).transactions());
+    }
+
+    @Test
+    void sellInventory_succeeds_removes_all_sellable_items_and_deposits() {
+        loadProviderPlugin(Mockito.mock(Economy.class));
+        var plugin = loadPlugin(com.skyblockexp.ezshops.EzShopsPlugin.class);
+
+        ShopPricingManager pm = Mockito.mock(ShopPricingManager.class);
+        ShopPrice diamondPrice = new ShopPrice(10.0, 5.0);
+        ShopPrice ironPrice = new ShopPrice(3.0, 1.5);
+        when(pm.getPrice(eq(Material.DIAMOND))).thenReturn(Optional.of(diamondPrice));
+        when(pm.getPrice(eq(Material.IRON_INGOT))).thenReturn(Optional.of(ironPrice));
+        when(pm.estimateBulkTotal(eq(Material.DIAMOND), eq(4), any())).thenReturn(20.0);
+        when(pm.estimateBulkTotal(eq(Material.IRON_INGOT), eq(6), any())).thenReturn(9.0);
+
+        Economy econ = Mockito.mock(Economy.class);
+        when(econ.depositPlayer((org.bukkit.OfflinePlayer) any(), anyDouble()))
+                .thenReturn(new EconomyResponse(0.0, 1000.0, EconomyResponse.ResponseType.SUCCESS, "ok"));
+        when(econ.format(anyDouble())).thenReturn("$0.00");
+
+        ShopTransactionService svc = buildService(pm, econ, plugin);
+
+        Player player = server.addPlayer("seller");
+        player.addAttachment(plugin, ShopTransactionService.PERMISSION_SELL, true);
+        player.getInventory().addItem(new ItemStack(Material.DIAMOND, 4));
+        player.getInventory().addItem(new ItemStack(Material.IRON_INGOT, 6));
+
+        ShopTransactionResult result = svc.sellInventory(player);
+
+        assertTrue(result.success(), "Expected success but got: " + result.message());
+        verify(econ).depositPlayer((org.bukkit.OfflinePlayer) any(), eq(29.0));
+
+        // Verify all sellable items were removed
+        int diamonds = 0, iron = 0;
+        for (ItemStack stack : player.getInventory().getStorageContents()) {
+            if (stack == null) continue;
+            if (stack.getType() == Material.DIAMOND) diamonds += stack.getAmount();
+            if (stack.getType() == Material.IRON_INGOT) iron += stack.getAmount();
+        }
+        assertEquals(0, diamonds, "Diamonds should be removed after sellInventory");
+        assertEquals(0, iron, "Iron ingots should be removed after sellInventory");
+    }
+
+    @Test
+    void sellInventory_fails_when_economy_is_null() {
+        loadProviderPlugin(Mockito.mock(Economy.class));
+        var plugin = loadPlugin(com.skyblockexp.ezshops.EzShopsPlugin.class);
+
+        ShopPricingManager pm = Mockito.mock(ShopPricingManager.class);
+        ShopTransactionService svc = buildService(pm, null, plugin);
+
+        Player player = server.addPlayer("seller");
+        player.addAttachment(plugin, ShopTransactionService.PERMISSION_SELL, true);
+        player.getInventory().addItem(new ItemStack(Material.DIAMOND, 1));
+
+        ShopTransactionResult result = svc.sellInventory(player);
+
+        assertFalse(result.success());
+        assertEquals(ShopMessageConfiguration.load(plugin).transactions().errors().noEconomy(), result.message());
+    }
+
+    @Test
+    void sellInventory_fails_when_player_lacks_sell_permission() {
+        loadProviderPlugin(Mockito.mock(Economy.class));
+        var plugin = loadPlugin(com.skyblockexp.ezshops.EzShopsPlugin.class);
+
+        ShopPricingManager pm = Mockito.mock(ShopPricingManager.class);
+        Economy econ = Mockito.mock(Economy.class);
+        ShopTransactionService svc = buildService(pm, econ, plugin);
+
+        Player player = server.addPlayer("seller"); // no permission
+
+        ShopTransactionResult result = svc.sellInventory(player);
+
+        assertFalse(result.success());
+        assertEquals(ShopMessageConfiguration.load(plugin).transactions().errors().noSellPermission(), result.message());
+        verify(econ, never()).depositPlayer((org.bukkit.OfflinePlayer) any(), anyDouble());
+    }
+
+    @Test
+    void sellInventory_fails_when_inventory_has_no_sellable_items() {
+        loadProviderPlugin(Mockito.mock(Economy.class));
+        var plugin = loadPlugin(com.skyblockexp.ezshops.EzShopsPlugin.class);
+
+        ShopPricingManager pm = Mockito.mock(ShopPricingManager.class);
+        // No prices configured for anything — all getPrice() calls return empty
+        when(pm.getPrice(any(Material.class))).thenReturn(Optional.empty());
+        Economy econ = Mockito.mock(Economy.class);
+        when(econ.format(anyDouble())).thenReturn("$0.00");
+        ShopTransactionService svc = buildService(pm, econ, plugin);
+
+        Player player = server.addPlayer("seller");
+        player.addAttachment(plugin, ShopTransactionService.PERMISSION_SELL, true);
+        player.getInventory().addItem(new ItemStack(Material.COBBLESTONE, 64));
+
+        ShopTransactionResult result = svc.sellInventory(player);
+
+        assertFalse(result.success());
+        verify(econ, never()).depositPlayer((org.bukkit.OfflinePlayer) any(), anyDouble());
+    }
+
+    @Test
+    void sellInventory_skips_items_whose_sell_price_is_disabled() {
+        loadProviderPlugin(Mockito.mock(Economy.class));
+        var plugin = loadPlugin(com.skyblockexp.ezshops.EzShopsPlugin.class);
+
+        ShopPricingManager pm = Mockito.mock(ShopPricingManager.class);
+        // DIAMOND: canSell() = false (sellPrice < 0)
+        when(pm.getPrice(eq(Material.DIAMOND))).thenReturn(Optional.of(new ShopPrice(10.0, -1.0)));
+        // IRON_INGOT: sellable
+        ShopPrice ironPrice = new ShopPrice(3.0, 2.0);
+        when(pm.getPrice(eq(Material.IRON_INGOT))).thenReturn(Optional.of(ironPrice));
+        when(pm.estimateBulkTotal(eq(Material.IRON_INGOT), eq(3), any())).thenReturn(6.0);
+
+        Economy econ = Mockito.mock(Economy.class);
+        when(econ.depositPlayer((org.bukkit.OfflinePlayer) any(), anyDouble()))
+                .thenReturn(new EconomyResponse(0.0, 1000.0, EconomyResponse.ResponseType.SUCCESS, "ok"));
+        when(econ.format(anyDouble())).thenReturn("$0.00");
+
+        ShopTransactionService svc = buildService(pm, econ, plugin);
+
+        Player player = server.addPlayer("seller");
+        player.addAttachment(plugin, ShopTransactionService.PERMISSION_SELL, true);
+        player.getInventory().addItem(new ItemStack(Material.DIAMOND, 5));
+        player.getInventory().addItem(new ItemStack(Material.IRON_INGOT, 3));
+
+        ShopTransactionResult result = svc.sellInventory(player);
+
+        assertTrue(result.success(), "Expected success selling iron ingots");
+        // Only iron ingots should have been sold — deposit = 6.0
+        verify(econ).depositPlayer((org.bukkit.OfflinePlayer) any(), eq(6.0));
+        // Diamonds should remain in inventory
+        int diamonds = 0;
+        for (ItemStack stack : player.getInventory().getStorageContents()) {
+            if (stack != null && stack.getType() == Material.DIAMOND) diamonds += stack.getAmount();
+        }
+        assertEquals(5, diamonds, "Non-sellable diamonds should remain in inventory");
+    }
+
+    @Test
+    void sellInventory_fails_economy_deposit_rejected_and_items_are_refunded() {
+        loadProviderPlugin(Mockito.mock(Economy.class));
+        var plugin = loadPlugin(com.skyblockexp.ezshops.EzShopsPlugin.class);
+
+        ShopPricingManager pm = Mockito.mock(ShopPricingManager.class);
+        ShopPrice price = new ShopPrice(10.0, 5.0);
+        when(pm.getPrice(eq(Material.DIAMOND))).thenReturn(Optional.of(price));
+        when(pm.estimateBulkTotal(eq(Material.DIAMOND), eq(2), any())).thenReturn(10.0);
+
+        Economy econ = Mockito.mock(Economy.class);
+        when(econ.depositPlayer((org.bukkit.OfflinePlayer) any(), anyDouble()))
+                .thenReturn(new EconomyResponse(0.0, 0.0, EconomyResponse.ResponseType.FAILURE, "bank error"));
+        when(econ.format(anyDouble())).thenReturn("$0.00");
+
+        ShopTransactionService svc = buildService(pm, econ, plugin);
+
+        Player player = server.addPlayer("seller");
+        player.addAttachment(plugin, ShopTransactionService.PERMISSION_SELL, true);
+        player.getInventory().addItem(new ItemStack(Material.DIAMOND, 2));
+
+        ShopTransactionResult result = svc.sellInventory(player);
+
+        assertFalse(result.success());
+        verify(econ).depositPlayer((org.bukkit.OfflinePlayer) any(), anyDouble());
+        // Items should be refunded to the player
+        int remaining = 0;
+        for (ItemStack stack : player.getInventory().getStorageContents()) {
+            if (stack != null && stack.getType() == Material.DIAMOND) remaining += stack.getAmount();
+        }
+        assertEquals(2, remaining, "Items should be returned to player when sellInventory deposit fails");
+    }
+}

--- a/src/test/java/com/skyblockexp/ezshops/shop/ShopSellTransactionTest.java
+++ b/src/test/java/com/skyblockexp/ezshops/shop/ShopSellTransactionTest.java
@@ -1,0 +1,402 @@
+package com.skyblockexp.ezshops.shop;
+
+import com.skyblockexp.ezshops.AbstractEzShopsTest;
+import com.skyblockexp.ezshops.config.ShopMessageConfiguration;
+import net.milkbowl.vault.economy.Economy;
+import net.milkbowl.vault.economy.EconomyResponse;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Feature tests for {@link ShopTransactionService#sell(Player, Material, int)}
+ * and {@link ShopTransactionService#sellDirect(Player, Material, int)}.
+ */
+public class ShopSellTransactionTest extends AbstractEzShopsTest {
+
+    // ─── Helpers ─────────────────────────────────────────────────────────────
+
+    private ShopTransactionService buildService(ShopPricingManager pricingManager, Economy economy,
+            com.skyblockexp.ezshops.EzShopsPlugin plugin) {
+        return new ShopTransactionService(pricingManager, economy,
+                ShopMessageConfiguration.load(plugin).transactions());
+    }
+
+    private ShopPricingManager sellableManager(Material material, double sellPrice, int amount) {
+        ShopPricingManager pm = Mockito.mock(ShopPricingManager.class);
+        ShopPrice price = new ShopPrice(sellPrice * 2, sellPrice); // buyPrice > 0, sellPrice > 0
+        when(pm.getPrice(eq(material))).thenReturn(Optional.of(price));
+        when(pm.estimateBulkTotal(eq(material), eq(amount), any())).thenReturn(sellPrice * amount);
+        return pm;
+    }
+
+    private Economy successEconomy(double balance) {
+        Economy econ = Mockito.mock(Economy.class);
+        when(econ.getBalance((org.bukkit.OfflinePlayer) any())).thenReturn(balance);
+        when(econ.depositPlayer((org.bukkit.OfflinePlayer) any(), anyDouble()))
+                .thenReturn(new EconomyResponse(0.0, balance, EconomyResponse.ResponseType.SUCCESS, "ok"));
+        when(econ.format(anyDouble())).thenReturn("$0.00");
+        return econ;
+    }
+
+    // ─── sell(Player, Material, int) ─────────────────────────────────────────
+
+    @Test
+    void sell_succeeds_removes_items_from_inventory_and_deposits_money() {
+        loadProviderPlugin(Mockito.mock(Economy.class));
+        var plugin = loadPlugin(com.skyblockexp.ezshops.EzShopsPlugin.class);
+
+        ShopPricingManager pm = sellableManager(Material.DIAMOND, 5.0, 16);
+        Economy econ = successEconomy(0.0);
+        ShopTransactionService svc = buildService(pm, econ, plugin);
+
+        Player player = server.addPlayer("seller");
+        player.addAttachment(plugin, ShopTransactionService.PERMISSION_SELL, true);
+        player.getInventory().addItem(new ItemStack(Material.DIAMOND, 16));
+
+        ShopTransactionResult result = svc.sell(player, Material.DIAMOND, 16);
+
+        assertTrue(result.success(), "Expected success but got: " + result.message());
+        verify(econ).depositPlayer((org.bukkit.OfflinePlayer) any(), eq(80.0));
+        // Items should have been removed from the player's inventory
+        int remaining = 0;
+        for (ItemStack stack : player.getInventory().getStorageContents()) {
+            if (stack != null && stack.getType() == Material.DIAMOND) {
+                remaining += stack.getAmount();
+            }
+        }
+        assertEquals(0, remaining, "Items should be removed from player inventory after successful sell");
+    }
+
+    @Test
+    void sell_fails_when_economy_is_null() {
+        loadProviderPlugin(Mockito.mock(Economy.class));
+        var plugin = loadPlugin(com.skyblockexp.ezshops.EzShopsPlugin.class);
+
+        ShopPricingManager pm = Mockito.mock(ShopPricingManager.class);
+        ShopTransactionService svc = buildService(pm, null, plugin);
+
+        Player player = server.addPlayer("seller");
+        player.addAttachment(plugin, ShopTransactionService.PERMISSION_SELL, true);
+
+        ShopTransactionResult result = svc.sell(player, Material.DIAMOND, 1);
+
+        assertFalse(result.success());
+        assertEquals(ShopMessageConfiguration.load(plugin).transactions().errors().noEconomy(), result.message());
+    }
+
+    @Test
+    void sell_fails_when_player_lacks_sell_permission() {
+        loadProviderPlugin(Mockito.mock(Economy.class));
+        var plugin = loadPlugin(com.skyblockexp.ezshops.EzShopsPlugin.class);
+
+        ShopPricingManager pm = sellableManager(Material.DIAMOND, 5.0, 1);
+        Economy econ = successEconomy(0.0);
+        ShopTransactionService svc = buildService(pm, econ, plugin);
+
+        // Player intentionally has NO sell permission
+        Player player = server.addPlayer("seller");
+
+        ShopTransactionResult result = svc.sell(player, Material.DIAMOND, 1);
+
+        assertFalse(result.success());
+        assertEquals(ShopMessageConfiguration.load(plugin).transactions().errors().noSellPermission(), result.message());
+        verify(econ, never()).depositPlayer((org.bukkit.OfflinePlayer) any(), anyDouble());
+    }
+
+    @Test
+    void sell_fails_when_amount_is_not_positive() {
+        loadProviderPlugin(Mockito.mock(Economy.class));
+        var plugin = loadPlugin(com.skyblockexp.ezshops.EzShopsPlugin.class);
+
+        ShopPricingManager pm = Mockito.mock(ShopPricingManager.class);
+        Economy econ = successEconomy(0.0);
+        ShopTransactionService svc = buildService(pm, econ, plugin);
+
+        Player player = server.addPlayer("seller");
+        player.addAttachment(plugin, ShopTransactionService.PERMISSION_SELL, true);
+
+        ShopTransactionResult resultZero = svc.sell(player, Material.DIAMOND, 0);
+        ShopTransactionResult resultNeg = svc.sell(player, Material.DIAMOND, -5);
+
+        assertFalse(resultZero.success());
+        assertFalse(resultNeg.success());
+        assertEquals(ShopMessageConfiguration.load(plugin).transactions().errors().amountPositive(), resultZero.message());
+        assertEquals(ShopMessageConfiguration.load(plugin).transactions().errors().amountPositive(), resultNeg.message());
+        verify(econ, never()).depositPlayer((org.bukkit.OfflinePlayer) any(), anyDouble());
+    }
+
+    @Test
+    void sell_fails_when_price_not_configured() {
+        loadProviderPlugin(Mockito.mock(Economy.class));
+        var plugin = loadPlugin(com.skyblockexp.ezshops.EzShopsPlugin.class);
+
+        ShopPricingManager pm = Mockito.mock(ShopPricingManager.class);
+        when(pm.getPrice(eq(Material.DIAMOND))).thenReturn(Optional.empty());
+        Economy econ = successEconomy(0.0);
+        ShopTransactionService svc = buildService(pm, econ, plugin);
+
+        Player player = server.addPlayer("seller");
+        player.addAttachment(plugin, ShopTransactionService.PERMISSION_SELL, true);
+
+        ShopTransactionResult result = svc.sell(player, Material.DIAMOND, 1);
+
+        assertFalse(result.success());
+        assertEquals(ShopMessageConfiguration.load(plugin).transactions().errors().notConfigured(), result.message());
+        verify(econ, never()).depositPlayer((org.bukkit.OfflinePlayer) any(), anyDouble());
+    }
+
+    @Test
+    void sell_fails_when_material_is_not_sellable() {
+        loadProviderPlugin(Mockito.mock(Economy.class));
+        var plugin = loadPlugin(com.skyblockexp.ezshops.EzShopsPlugin.class);
+
+        // ShopPrice(buyPrice, sellPrice) — sellPrice = -1 means canSell() = false
+        ShopPricingManager pm = Mockito.mock(ShopPricingManager.class);
+        when(pm.getPrice(eq(Material.DIAMOND))).thenReturn(Optional.of(new ShopPrice(10.0, -1.0)));
+        Economy econ = successEconomy(0.0);
+        ShopTransactionService svc = buildService(pm, econ, plugin);
+
+        Player player = server.addPlayer("seller");
+        player.addAttachment(plugin, ShopTransactionService.PERMISSION_SELL, true);
+
+        ShopTransactionResult result = svc.sell(player, Material.DIAMOND, 1);
+
+        assertFalse(result.success());
+        assertEquals(ShopMessageConfiguration.load(plugin).transactions().errors().notSellable(), result.message());
+        verify(econ, never()).depositPlayer((org.bukkit.OfflinePlayer) any(), anyDouble());
+    }
+
+    @Test
+    void sell_fails_when_player_has_insufficient_items() {
+        loadProviderPlugin(Mockito.mock(Economy.class));
+        var plugin = loadPlugin(com.skyblockexp.ezshops.EzShopsPlugin.class);
+
+        ShopPricingManager pm = sellableManager(Material.DIAMOND, 5.0, 16);
+        Economy econ = successEconomy(0.0);
+        ShopTransactionService svc = buildService(pm, econ, plugin);
+
+        Player player = server.addPlayer("seller");
+        player.addAttachment(plugin, ShopTransactionService.PERMISSION_SELL, true);
+        // Player only has 5 diamonds, tries to sell 16
+        player.getInventory().addItem(new ItemStack(Material.DIAMOND, 5));
+
+        ShopTransactionResult result = svc.sell(player, Material.DIAMOND, 16);
+
+        assertFalse(result.success());
+        assertEquals(ShopMessageConfiguration.load(plugin).transactions().errors().insufficientItems(), result.message());
+        verify(econ, never()).depositPlayer((org.bukkit.OfflinePlayer) any(), anyDouble());
+    }
+
+    @Test
+    void sell_fails_when_economy_deposit_is_rejected_and_items_are_refunded() {
+        loadProviderPlugin(Mockito.mock(Economy.class));
+        var plugin = loadPlugin(com.skyblockexp.ezshops.EzShopsPlugin.class);
+
+        ShopPricingManager pm = sellableManager(Material.DIAMOND, 5.0, 4);
+        Economy econ = Mockito.mock(Economy.class);
+        when(econ.depositPlayer((org.bukkit.OfflinePlayer) any(), anyDouble()))
+                .thenReturn(new EconomyResponse(0.0, 0.0, EconomyResponse.ResponseType.FAILURE, "bank offline"));
+        when(econ.format(anyDouble())).thenReturn("$0.00");
+        ShopTransactionService svc = buildService(pm, econ, plugin);
+
+        Player player = server.addPlayer("seller");
+        player.addAttachment(plugin, ShopTransactionService.PERMISSION_SELL, true);
+        player.getInventory().addItem(new ItemStack(Material.DIAMOND, 4));
+
+        ShopTransactionResult result = svc.sell(player, Material.DIAMOND, 4);
+
+        assertFalse(result.success(), "Expected failure when economy deposit is rejected");
+        verify(econ).depositPlayer((org.bukkit.OfflinePlayer) any(), anyDouble());
+        // Items should be refunded — player should have diamonds back
+        int remaining = 0;
+        for (ItemStack stack : player.getInventory().getStorageContents()) {
+            if (stack != null && stack.getType() == Material.DIAMOND) {
+                remaining += stack.getAmount();
+            }
+        }
+        assertEquals(4, remaining, "Items should be returned to player when economy deposit fails");
+    }
+
+    @Test
+    void sell_triggers_handleSale_on_pricing_manager_after_success() {
+        loadProviderPlugin(Mockito.mock(Economy.class));
+        var plugin = loadPlugin(com.skyblockexp.ezshops.EzShopsPlugin.class);
+
+        ShopPricingManager pm = sellableManager(Material.IRON_INGOT, 2.0, 10);
+        Economy econ = successEconomy(0.0);
+        ShopTransactionService svc = buildService(pm, econ, plugin);
+
+        Player player = server.addPlayer("seller");
+        player.addAttachment(plugin, ShopTransactionService.PERMISSION_SELL, true);
+        player.getInventory().addItem(new ItemStack(Material.IRON_INGOT, 10));
+
+        ShopTransactionResult result = svc.sell(player, Material.IRON_INGOT, 10);
+
+        assertTrue(result.success(), "Expected success but got: " + result.message());
+        verify(pm).handleSale(eq(Material.IRON_INGOT), eq(10));
+    }
+
+    // ─── sellDirect(Player, Material, int) ───────────────────────────────────
+
+    @Test
+    void sellDirect_succeeds_without_requiring_items_in_player_inventory() {
+        loadProviderPlugin(Mockito.mock(Economy.class));
+        var plugin = loadPlugin(com.skyblockexp.ezshops.EzShopsPlugin.class);
+
+        ShopPricingManager pm = sellableManager(Material.DIAMOND, 5.0, 8);
+        Economy econ = successEconomy(0.0);
+        ShopTransactionService svc = buildService(pm, econ, plugin);
+
+        Player player = server.addPlayer("seller");
+        player.addAttachment(plugin, ShopTransactionService.PERMISSION_SELL, true);
+        // No diamonds in inventory — items are assumed to already be in an external source
+
+        ShopTransactionResult result = svc.sellDirect(player, Material.DIAMOND, 8);
+
+        assertTrue(result.success(), "Expected success but got: " + result.message());
+        verify(econ).depositPlayer((org.bukkit.OfflinePlayer) any(), eq(40.0));
+    }
+
+    @Test
+    void sellDirect_fails_when_player_lacks_sell_permission() {
+        loadProviderPlugin(Mockito.mock(Economy.class));
+        var plugin = loadPlugin(com.skyblockexp.ezshops.EzShopsPlugin.class);
+
+        ShopPricingManager pm = sellableManager(Material.DIAMOND, 5.0, 1);
+        Economy econ = successEconomy(0.0);
+        ShopTransactionService svc = buildService(pm, econ, plugin);
+
+        Player player = server.addPlayer("seller"); // no permission added
+
+        ShopTransactionResult result = svc.sellDirect(player, Material.DIAMOND, 1);
+
+        assertFalse(result.success());
+        assertEquals(ShopMessageConfiguration.load(plugin).transactions().errors().noSellPermission(), result.message());
+        verify(econ, never()).depositPlayer((org.bukkit.OfflinePlayer) any(), anyDouble());
+    }
+
+    @Test
+    void sellDirect_fails_when_amount_is_not_positive() {
+        loadProviderPlugin(Mockito.mock(Economy.class));
+        var plugin = loadPlugin(com.skyblockexp.ezshops.EzShopsPlugin.class);
+
+        ShopPricingManager pm = sellableManager(Material.DIAMOND, 5.0, 1);
+        Economy econ = successEconomy(0.0);
+        ShopTransactionService svc = buildService(pm, econ, plugin);
+
+        Player player = server.addPlayer("seller");
+        player.addAttachment(plugin, ShopTransactionService.PERMISSION_SELL, true);
+
+        ShopTransactionResult result = svc.sellDirect(player, Material.DIAMOND, 0);
+
+        assertFalse(result.success());
+        assertEquals(ShopMessageConfiguration.load(plugin).transactions().errors().amountPositive(), result.message());
+        verify(econ, never()).depositPlayer((org.bukkit.OfflinePlayer) any(), anyDouble());
+    }
+
+    @Test
+    void sellDirect_fails_when_price_not_configured() {
+        loadProviderPlugin(Mockito.mock(Economy.class));
+        var plugin = loadPlugin(com.skyblockexp.ezshops.EzShopsPlugin.class);
+
+        ShopPricingManager pm = Mockito.mock(ShopPricingManager.class);
+        when(pm.getPrice(eq(Material.GOLD_INGOT))).thenReturn(Optional.empty());
+        Economy econ = successEconomy(0.0);
+        ShopTransactionService svc = buildService(pm, econ, plugin);
+
+        Player player = server.addPlayer("seller");
+        player.addAttachment(plugin, ShopTransactionService.PERMISSION_SELL, true);
+
+        ShopTransactionResult result = svc.sellDirect(player, Material.GOLD_INGOT, 1);
+
+        assertFalse(result.success());
+        assertEquals(ShopMessageConfiguration.load(plugin).transactions().errors().notConfigured(), result.message());
+        verify(econ, never()).depositPlayer((org.bukkit.OfflinePlayer) any(), anyDouble());
+    }
+
+    @Test
+    void sellDirect_fails_when_economy_deposit_is_rejected_and_no_item_refund_occurs() {
+        loadProviderPlugin(Mockito.mock(Economy.class));
+        var plugin = loadPlugin(com.skyblockexp.ezshops.EzShopsPlugin.class);
+
+        ShopPricingManager pm = sellableManager(Material.DIAMOND, 5.0, 4);
+        Economy econ = Mockito.mock(Economy.class);
+        when(econ.depositPlayer((org.bukkit.OfflinePlayer) any(), anyDouble()))
+                .thenReturn(new EconomyResponse(0.0, 0.0, EconomyResponse.ResponseType.FAILURE, "error"));
+        when(econ.format(anyDouble())).thenReturn("$0.00");
+        ShopTransactionService svc = buildService(pm, econ, plugin);
+
+        Player player = server.addPlayer("seller");
+        player.addAttachment(plugin, ShopTransactionService.PERMISSION_SELL, true);
+        // No items in inventory because they were already moved to the GUI
+
+        ShopTransactionResult result = svc.sellDirect(player, Material.DIAMOND, 4);
+
+        assertFalse(result.success());
+        verify(econ).depositPlayer((org.bukkit.OfflinePlayer) any(), anyDouble());
+        // Player should still have NO items (no refund for direct sell)
+        int remaining = 0;
+        for (ItemStack stack : player.getInventory().getStorageContents()) {
+            if (stack != null && stack.getType() == Material.DIAMOND) {
+                remaining += stack.getAmount();
+            }
+        }
+        assertEquals(0, remaining, "sellDirect should not refund items on economy failure — they belong to the GUI");
+    }
+
+    @Test
+    void sellDirect_succeeds_for_item_that_is_in_rotation_but_not_currently_visible() {
+        // Regression: the Quick Sell GUI must accept all configured items regardless of rotation.
+        // Previously sellDirect applied the same rotation guard as sell(), so items like BIRCH_LOG
+        // that are configured but whose rotation slot is inactive would return notInRotation.
+        loadProviderPlugin(Mockito.mock(Economy.class));
+        var plugin = loadPlugin(com.skyblockexp.ezshops.EzShopsPlugin.class);
+
+        ShopPricingManager pm = Mockito.mock(ShopPricingManager.class);
+        ShopPrice price = new ShopPrice(10.0, 3.0);
+        when(pm.getPrice(eq(Material.BIRCH_LOG))).thenReturn(Optional.of(price));
+        when(pm.estimateBulkTotal(eq(Material.BIRCH_LOG), eq(8), any())).thenReturn(24.0);
+        // Simulate: item is part of a rotation but its rotation slot is inactive
+        when(pm.isVisibleInMenu(Material.BIRCH_LOG)).thenReturn(false);
+        when(pm.isPartOfRotation(Material.BIRCH_LOG)).thenReturn(true);
+
+        Economy econ = successEconomy(0.0);
+        ShopTransactionService svc = buildService(pm, econ, plugin);
+
+        Player player = server.addPlayer("seller");
+        player.addAttachment(plugin, ShopTransactionService.PERMISSION_SELL, true);
+
+        ShopTransactionResult result = svc.sellDirect(player, Material.BIRCH_LOG, 8);
+
+        assertTrue(result.success(),
+                "sellDirect should bypass rotation guard — quick sell GUI accepts all configured items. Got: "
+                        + result.message());
+        verify(econ).depositPlayer((org.bukkit.OfflinePlayer) any(), eq(24.0));
+    }
+
+    @Test
+    void sellDirect_triggers_handleSale_on_pricing_manager_after_success() {
+        loadProviderPlugin(Mockito.mock(Economy.class));
+        var plugin = loadPlugin(com.skyblockexp.ezshops.EzShopsPlugin.class);
+
+        ShopPricingManager pm = sellableManager(Material.IRON_INGOT, 2.0, 6);
+        Economy econ = successEconomy(0.0);
+        ShopTransactionService svc = buildService(pm, econ, plugin);
+
+        Player player = server.addPlayer("seller");
+        player.addAttachment(plugin, ShopTransactionService.PERMISSION_SELL, true);
+
+        svc.sellDirect(player, Material.IRON_INGOT, 6);
+
+        verify(pm).handleSale(eq(Material.IRON_INGOT), eq(6));
+    }
+}

--- a/src/test/java/com/skyblockexp/ezshops/shop/WoodCategoryConfigLoadingTest.java
+++ b/src/test/java/com/skyblockexp/ezshops/shop/WoodCategoryConfigLoadingTest.java
@@ -103,6 +103,28 @@ public class WoodCategoryConfigLoadingTest extends AbstractEzShopsTest {
             assertTrue(price.get().canSell(),
                     stripped.name() + " should have a positive sell price (canSell == true)");
         }
+
+        // All wood (all-bark) variants added to the bundled wood.yml defaults.
+        // "Birch Wood" (BIRCH_WOOD) is the item players commonly confuse with "Birch Log".
+        Material[] expectedWoodBlocks = {
+                Material.OAK_WOOD,
+                Material.SPRUCE_WOOD,
+                Material.BIRCH_WOOD,
+                Material.JUNGLE_WOOD,
+                Material.ACACIA_WOOD,
+                Material.DARK_OAK_WOOD,
+                Material.MANGROVE_WOOD,
+                Material.PALE_OAK_WOOD,
+                Material.CHERRY_WOOD,
+        };
+
+        for (Material wood : expectedWoodBlocks) {
+            Optional<ShopPrice> price = pm.getPrice(wood);
+            assertTrue(price.isPresent(),
+                    wood.name() + " should be present in the price map after loading the bundled wood.yml");
+            assertTrue(price.get().canSell(),
+                    wood.name() + " should have a positive sell price (canSell == true)");
+        }
     }
 
     /**
@@ -226,6 +248,26 @@ public class WoodCategoryConfigLoadingTest extends AbstractEzShopsTest {
     // -----------------------------------------------------------------------
     // Expected-failure tests (items genuinely not in the shop)
     // -----------------------------------------------------------------------
+
+    /**
+     * BIRCH_WOOD (the all-bark "Birch Wood" block) must appear in the price map.
+     * Players sometimes have this item instead of BIRCH_LOG and expect to be able
+     * to sell it via /sellhand.
+     */
+    @Test
+    void birch_wood_is_priced_and_sellable() throws Exception {
+        Economy econ = mock(Economy.class);
+        loadProviderPlugin(econ);
+
+        EzShopsPlugin plugin = loadPlugin(EzShopsPlugin.class);
+        ShopPricingManager pm = getPricingManager(plugin);
+
+        Optional<ShopPrice> price = pm.getPrice(Material.BIRCH_WOOD);
+        assertTrue(price.isPresent(),
+                "BIRCH_WOOD must be present in the price map after loading the bundled wood.yml");
+        assertTrue(price.get().canSell(),
+                "BIRCH_WOOD must have a positive sell price");
+    }
 
     /**
      * STRIPPED_JUNGLE_LOG must appear in the price map now that it has been

--- a/src/test/java/com/skyblockexp/ezshops/shop/WoodCategoryConfigLoadingTest.java
+++ b/src/test/java/com/skyblockexp/ezshops/shop/WoodCategoryConfigLoadingTest.java
@@ -1,0 +1,378 @@
+package com.skyblockexp.ezshops.shop;
+
+import com.skyblockexp.ezshops.AbstractEzShopsTest;
+import com.skyblockexp.ezshops.EzShopsPlugin;
+import com.skyblockexp.ezshops.bootstrap.CoreShopComponent;
+import net.milkbowl.vault.economy.Economy;
+import net.milkbowl.vault.economy.EconomyResponse;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Integration tests that confirm the wood category items are all correctly
+ * loaded from the bundled wood.yml defaults and are sellable via the full
+ * shop pipeline.
+ *
+ * <p>These tests exist to guard against regressions where items like BIRCH_LOG
+ * appear to be missing from the price map after a fresh plugin load.</p>
+ */
+public class WoodCategoryConfigLoadingTest extends AbstractEzShopsTest {
+
+    // -----------------------------------------------------------------------
+    // Price-map loading tests
+    // -----------------------------------------------------------------------
+
+    /**
+     * Confirms that every standard log type present in the bundled wood.yml
+     * is registered in the pricing manager's price map and has a positive
+     * sell price after a fresh plugin load.
+     *
+     * <p>If BIRCH_LOG, JUNGLE_LOG or any other log type is missing from the
+     * price map this test will fail, reproducing the "not configured" error
+     * that players see when they try to /sellhand one of these items.</p>
+     */
+    @Test
+    void all_wood_category_logs_are_priced_and_sellable_after_fresh_load() throws Exception {
+        Economy econ = mock(Economy.class);
+        when(econ.format(anyDouble())).thenReturn("$0.00");
+        when(econ.depositPlayer(any(org.bukkit.OfflinePlayer.class), anyDouble()))
+                .thenReturn(new EconomyResponse(0, 1000, EconomyResponse.ResponseType.SUCCESS, ""));
+        loadProviderPlugin(econ);
+
+        EzShopsPlugin plugin = loadPlugin(EzShopsPlugin.class);
+        assertNotNull(plugin);
+
+        ShopPricingManager pm = getPricingManager(plugin);
+
+        // All logs that appear in the bundled shop/categories/wood.yml
+        Material[] expectedLogs = {
+                Material.OAK_LOG,
+                Material.SPRUCE_LOG,
+                Material.BIRCH_LOG,
+                Material.JUNGLE_LOG,
+                Material.ACACIA_LOG,
+                Material.DARK_OAK_LOG,
+                Material.MANGROVE_LOG,
+                Material.PALE_OAK_LOG,
+                Material.CHERRY_LOG,
+        };
+
+        for (Material log : expectedLogs) {
+            Optional<ShopPrice> price = pm.getPrice(log);
+            assertTrue(price.isPresent(),
+                    log.name() + " should be present in the price map after loading the bundled wood.yml");
+            assertTrue(price.get().canSell(),
+                    log.name() + " should have a positive sell price (canSell == true)");
+        }
+    }
+
+    /**
+     * BIRCH_LOG specifically must appear in {@code getConfiguredMaterials()}.
+     * This is a targeted regression test for the bug where BIRCH_LOG was
+     * reported as "not configured" despite being listed in wood.yml.
+     */
+    @Test
+    void birch_log_is_in_configured_materials() throws Exception {
+        Economy econ = mock(Economy.class);
+        loadProviderPlugin(econ);
+
+        EzShopsPlugin plugin = loadPlugin(EzShopsPlugin.class);
+        ShopPricingManager pm = getPricingManager(plugin);
+
+        Set<Material> configured = pm.getConfiguredMaterials();
+        assertTrue(configured.contains(Material.BIRCH_LOG),
+                "BIRCH_LOG must be in getConfiguredMaterials(); got: " + configured);
+    }
+
+    /**
+     * JUNGLE_LOG specifically must appear in the price map with a sell price.
+     */
+    @Test
+    void jungle_log_is_priced_and_sellable() throws Exception {
+        Economy econ = mock(Economy.class);
+        loadProviderPlugin(econ);
+
+        EzShopsPlugin plugin = loadPlugin(EzShopsPlugin.class);
+        ShopPricingManager pm = getPricingManager(plugin);
+
+        Optional<ShopPrice> price = pm.getPrice(Material.JUNGLE_LOG);
+        assertTrue(price.isPresent(), "JUNGLE_LOG should be present in the price map");
+        assertTrue(price.get().canSell(), "JUNGLE_LOG should be sellable");
+    }
+
+    // -----------------------------------------------------------------------
+    // End-to-end sell pipeline tests
+    // -----------------------------------------------------------------------
+
+    /**
+     * Simulates "/sellhand" for a player holding BIRCH_LOG.  The transaction
+     * must succeed, depositing money into the player's economy account.
+     *
+     * <p>Previously this returned "That item is not configured in the shop."
+     * because {@code getPrice(BIRCH_LOG)} returned empty.</p>
+     */
+    @Test
+    void sellhand_birch_log_succeeds() throws Exception {
+        Economy econ = mock(Economy.class);
+        when(econ.format(anyDouble())).thenReturn("$0.00");
+        when(econ.depositPlayer(any(org.bukkit.OfflinePlayer.class), anyDouble()))
+                .thenReturn(new EconomyResponse(0, 1000, EconomyResponse.ResponseType.SUCCESS, ""));
+        loadProviderPlugin(econ);
+
+        EzShopsPlugin plugin = loadPlugin(EzShopsPlugin.class);
+        ShopTransactionService txService = getTransactionService(plugin);
+
+        PlayerMock player = server.addPlayer("birch-seller");
+        player.addAttachment(plugin, ShopTransactionService.PERMISSION_SELL, true);
+
+        // Give the player some birch logs to sell
+        ItemStack birchStack = new ItemStack(Material.BIRCH_LOG, 16);
+        player.getInventory().addItem(birchStack);
+
+        ShopTransactionResult result = txService.sell(player, Material.BIRCH_LOG, 16);
+        assertTrue(result.success(),
+                "Selling BIRCH_LOG should succeed, but got: " + result.message());
+        verify(econ, atLeastOnce()).depositPlayer(eq(player), anyDouble());
+    }
+
+    /**
+     * Simulates "/sellhand" for a player holding JUNGLE_LOG.  The transaction
+     * must succeed.
+     */
+    @Test
+    void sellhand_jungle_log_succeeds() throws Exception {
+        Economy econ = mock(Economy.class);
+        when(econ.format(anyDouble())).thenReturn("$0.00");
+        when(econ.depositPlayer(any(org.bukkit.OfflinePlayer.class), anyDouble()))
+                .thenReturn(new EconomyResponse(0, 1000, EconomyResponse.ResponseType.SUCCESS, ""));
+        loadProviderPlugin(econ);
+
+        EzShopsPlugin plugin = loadPlugin(EzShopsPlugin.class);
+        ShopTransactionService txService = getTransactionService(plugin);
+
+        PlayerMock player = server.addPlayer("jungle-seller");
+        player.addAttachment(plugin, ShopTransactionService.PERMISSION_SELL, true);
+        player.getInventory().addItem(new ItemStack(Material.JUNGLE_LOG, 16));
+
+        ShopTransactionResult result = txService.sell(player, Material.JUNGLE_LOG, 16);
+        assertTrue(result.success(),
+                "Selling JUNGLE_LOG should succeed, but got: " + result.message());
+    }
+
+    /**
+     * Simulates the Quick Sell GUI's {@code sellDirect} path for BIRCH_LOG.
+     * Previously this returned "That item cannot be sold in the shop."
+     * because {@code isSellable} called {@code getPrice} which returned empty.
+     */
+    @Test
+    void sellDirect_birch_log_succeeds() throws Exception {
+        Economy econ = mock(Economy.class);
+        when(econ.format(anyDouble())).thenReturn("$0.00");
+        when(econ.depositPlayer(any(org.bukkit.OfflinePlayer.class), anyDouble()))
+                .thenReturn(new EconomyResponse(0, 1000, EconomyResponse.ResponseType.SUCCESS, ""));
+        loadProviderPlugin(econ);
+
+        EzShopsPlugin plugin = loadPlugin(EzShopsPlugin.class);
+        ShopTransactionService txService = getTransactionService(plugin);
+
+        PlayerMock player = server.addPlayer("birch-quick-seller");
+        player.addAttachment(plugin, ShopTransactionService.PERMISSION_SELL, true);
+
+        ShopTransactionResult result = txService.sellDirect(player, Material.BIRCH_LOG, 8);
+        assertTrue(result.success(),
+                "sellDirect for BIRCH_LOG should succeed, but got: " + result.message());
+        verify(econ, atLeastOnce()).depositPlayer(eq(player), anyDouble());
+    }
+
+    // -----------------------------------------------------------------------
+    // Expected-failure tests (items genuinely not in the shop)
+    // -----------------------------------------------------------------------
+
+    /**
+     * STRIPPED_JUNGLE_LOG is not in the bundled config — this should return
+     * "not configured", which is the correct/expected behaviour.
+     */
+    @Test
+    void stripped_jungle_log_is_not_configured() throws Exception {
+        Economy econ = mock(Economy.class);
+        loadProviderPlugin(econ);
+
+        EzShopsPlugin plugin = loadPlugin(EzShopsPlugin.class);
+        ShopPricingManager pm = getPricingManager(plugin);
+
+        assertFalse(pm.getPrice(Material.STRIPPED_JUNGLE_LOG).isPresent(),
+                "STRIPPED_JUNGLE_LOG is not in the bundled config and should not be priced");
+    }
+
+    /**
+     * OAK_PLANKS is not in the bundled config — this should return "not
+     * configured", which is the correct/expected behaviour.
+     */
+    @Test
+    void oak_planks_is_not_configured() throws Exception {
+        Economy econ = mock(Economy.class);
+        loadProviderPlugin(econ);
+
+        EzShopsPlugin plugin = loadPlugin(EzShopsPlugin.class);
+        ShopPricingManager pm = getPricingManager(plugin);
+
+        assertFalse(pm.getPrice(Material.OAK_PLANKS).isPresent(),
+                "OAK_PLANKS is not in the bundled config and should not be priced");
+    }
+
+    // -----------------------------------------------------------------------
+    // Legacy-format key-casing regression test
+    // -----------------------------------------------------------------------
+
+    /**
+     * Regression test for the key-casing bug in legacy (flat) shop configs.
+     *
+     * <p>When a server uses the legacy single-file format, material keys can be
+     * written in any case (e.g. {@code birch_log:} lowercase, {@code OAK_LOG:}
+     * uppercase).  Before the fix, {@code loadLegacyEntries} called
+     * {@code registerPrice(key, ...)} with the raw YAML key, so the priceMap
+     * entry was stored under whatever case appeared in the file.  Because
+     * {@code getPrice(Material)} always looks up {@code material.name()} which
+     * is SCREAMING_SNAKE_CASE (e.g. {@code "BIRCH_LOG"}), any key that was not
+     * written in upper-case was silently unreachable and players would see
+     * "That item is not configured in the shop." even though the item was in the
+     * config.</p>
+     *
+     * <p>After the fix, {@code loadLegacyEntries} normalises the key to
+     * {@code material.name()} before registering, so case in the config file no
+     * longer matters.</p>
+     */
+    @Test
+    void legacy_lowercase_config_key_is_found_by_getPrice() throws Exception {
+        Economy econ = mock(Economy.class);
+        when(econ.format(anyDouble())).thenReturn("$0.00");
+        loadProviderPlugin(econ);
+
+        // Pre-seed a tempDir with:
+        //  - shop.yml: legacy root-level format with a lowercase key ("birch_log")
+        //    and an uppercase key ("OAK_LOG") as control
+        //  - shop/categories/wood.yml: minimal stub with NO items, so BIRCH_LOG
+        //    can only reach getPrice() via the legacy registration path
+        Path tempDir = Files.createTempDirectory("legacy-key-casing-");
+        Path categoriesDir = tempDir.resolve("shop/categories");
+        Files.createDirectories(categoriesDir);
+
+        // OAK_LOG uses the uppercase key (control — this always worked).
+        // birch_log uses the lowercase key — this is what triggered the bug.
+        String legacyShopYml =
+                "OAK_LOG:\n"
+                + "  buy: 24.0\n"
+                + "  sell: 10.0\n"
+                + "birch_log:\n"
+                + "  buy: 26.0\n"
+                + "  sell: 11.0\n";
+        Files.writeString(tempDir.resolve("shop.yml"), legacyShopYml);
+
+        // Minimal wood.yml stub with NO items block so that BIRCH_LOG is NOT
+        // registered via the category code-path (only via legacy entries).
+        String emptyWoodYml =
+                "categories:\n"
+                + "  wood:\n"
+                + "    name: \"Wood\"\n"
+                + "    slot: 16\n"
+                + "    icon:\n"
+                + "      material: OAK_LOG\n"
+                + "      display-name: \"Wood\"\n"
+                + "      lore: []\n"
+                + "    menu:\n"
+                + "      title: \"Wood Shop\"\n"
+                + "      size: 54\n";
+        Files.writeString(categoriesDir.resolve("wood.yml"), emptyWoodYml);
+
+        EzShopsPlugin plugin = loadPluginWithDataFolder(EzShopsPlugin.class, tempDir.toFile());
+        ShopPricingManager pm = getPricingManager(plugin);
+
+        // OAK_LOG (uppercase key) is the control: it must always be found.
+        assertTrue(pm.getPrice(Material.OAK_LOG).isPresent(),
+                "OAK_LOG (uppercase legacy key) should be present in the price map");
+
+        // BIRCH_LOG (lowercase key "birch_log" in shop.yml) must be found after
+        // the fix.  Before the fix this returned empty because priceMap was keyed
+        // by "birch_log" while getPrice(Material) looks up "BIRCH_LOG".
+        assertTrue(pm.getPrice(Material.BIRCH_LOG).isPresent(),
+                "BIRCH_LOG must be found even when the legacy config uses the lowercase "
+                + "key 'birch_log' — loadLegacyEntries must normalise to material.name()");
+        assertTrue(pm.getPrice(Material.BIRCH_LOG).get().canSell(),
+                "BIRCH_LOG loaded from a lowercase legacy key must have a valid sell price");
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    /** Extracts the ShopPricingManager from the plugin via reflection. */
+    private ShopPricingManager getPricingManager(EzShopsPlugin plugin) throws Exception {
+        CoreShopComponent core = plugin.getCoreShopComponent();
+        assertNotNull(core, "CoreShopComponent must not be null");
+        Field f = CoreShopComponent.class.getDeclaredField("pricingManager");
+        f.setAccessible(true);
+        ShopPricingManager pm = (ShopPricingManager) f.get(core);
+        assertNotNull(pm, "ShopPricingManager must not be null");
+        return pm;
+    }
+
+    /** Extracts the ShopTransactionService from the plugin via reflection. */
+    private ShopTransactionService getTransactionService(EzShopsPlugin plugin) throws Exception {
+        CoreShopComponent core = plugin.getCoreShopComponent();
+        assertNotNull(core, "CoreShopComponent must not be null");
+        Field f = CoreShopComponent.class.getDeclaredField("transactionService");
+        f.setAccessible(true);
+        ShopTransactionService svc = (ShopTransactionService) f.get(core);
+        assertNotNull(svc, "ShopTransactionService must not be null");
+        return svc;
+    }
+
+    /**
+     * Like {@link #loadPlugin(Class)} but uses a caller-supplied dataFolder
+     * so that tests can pre-seed the directory with a custom configuration
+     * before the plugin's {@code onEnable()} copies default resources.
+     */
+    private <T extends org.bukkit.plugin.java.JavaPlugin> T loadPluginWithDataFolder(
+            Class<T> pluginClass, File dataFolder) {
+        try {
+            org.bukkit.plugin.PluginDescriptionFile description;
+            try (InputStream is = pluginClass.getResourceAsStream("/plugin.yml")) {
+                description = new org.bukkit.plugin.PluginDescriptionFile(is);
+            }
+            @SuppressWarnings("unchecked")
+            T plugin = (T) getUnsafeInstance().allocateInstance(pluginClass);
+            plugin.init(server, description, dataFolder, new File(""),
+                    pluginClass.getClassLoader(), description,
+                    java.util.logging.Logger.getLogger(description.getName()));
+            server.getPluginManager().registerLoadedPlugin(plugin);
+            server.getPluginManager().enablePlugin(plugin);
+            return plugin;
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to load plugin with custom dataFolder", e);
+        }
+    }
+
+    private static sun.misc.Unsafe getUnsafeInstance() throws Exception {
+        Field field = sun.misc.Unsafe.class.getDeclaredField("theUnsafe");
+        field.setAccessible(true);
+        return (sun.misc.Unsafe) field.get(null);
+    }
+}

--- a/src/test/java/com/skyblockexp/ezshops/shop/WoodCategoryConfigLoadingTest.java
+++ b/src/test/java/com/skyblockexp/ezshops/shop/WoodCategoryConfigLoadingTest.java
@@ -82,6 +82,27 @@ public class WoodCategoryConfigLoadingTest extends AbstractEzShopsTest {
             assertTrue(price.get().canSell(),
                     log.name() + " should have a positive sell price (canSell == true)");
         }
+
+        // All stripped log variants added to the bundled wood.yml defaults
+        Material[] expectedStrippedLogs = {
+                Material.STRIPPED_OAK_LOG,
+                Material.STRIPPED_SPRUCE_LOG,
+                Material.STRIPPED_BIRCH_LOG,
+                Material.STRIPPED_JUNGLE_LOG,
+                Material.STRIPPED_ACACIA_LOG,
+                Material.STRIPPED_DARK_OAK_LOG,
+                Material.STRIPPED_MANGROVE_LOG,
+                Material.STRIPPED_PALE_OAK_LOG,
+                Material.STRIPPED_CHERRY_LOG,
+        };
+
+        for (Material stripped : expectedStrippedLogs) {
+            Optional<ShopPrice> price = pm.getPrice(stripped);
+            assertTrue(price.isPresent(),
+                    stripped.name() + " should be present in the price map after loading the bundled wood.yml");
+            assertTrue(price.get().canSell(),
+                    stripped.name() + " should have a positive sell price (canSell == true)");
+        }
     }
 
     /**
@@ -207,35 +228,41 @@ public class WoodCategoryConfigLoadingTest extends AbstractEzShopsTest {
     // -----------------------------------------------------------------------
 
     /**
-     * STRIPPED_JUNGLE_LOG is not in the bundled config — this should return
-     * "not configured", which is the correct/expected behaviour.
+     * STRIPPED_JUNGLE_LOG must appear in the price map now that it has been
+     * added to the bundled wood.yml defaults.
      */
     @Test
-    void stripped_jungle_log_is_not_configured() throws Exception {
+    void stripped_jungle_log_is_priced_and_sellable() throws Exception {
         Economy econ = mock(Economy.class);
         loadProviderPlugin(econ);
 
         EzShopsPlugin plugin = loadPlugin(EzShopsPlugin.class);
         ShopPricingManager pm = getPricingManager(plugin);
 
-        assertFalse(pm.getPrice(Material.STRIPPED_JUNGLE_LOG).isPresent(),
-                "STRIPPED_JUNGLE_LOG is not in the bundled config and should not be priced");
+        Optional<ShopPrice> price = pm.getPrice(Material.STRIPPED_JUNGLE_LOG);
+        assertTrue(price.isPresent(),
+                "STRIPPED_JUNGLE_LOG must be present in the price map after loading the bundled wood.yml");
+        assertTrue(price.get().canSell(),
+                "STRIPPED_JUNGLE_LOG must have a positive sell price");
     }
 
     /**
-     * OAK_PLANKS is not in the bundled config — this should return "not
-     * configured", which is the correct/expected behaviour.
+     * OAK_PLANKS must appear in the price map now that planks have been added
+     * to the bundled building.yml defaults.
      */
     @Test
-    void oak_planks_is_not_configured() throws Exception {
+    void oak_planks_is_priced_and_sellable() throws Exception {
         Economy econ = mock(Economy.class);
         loadProviderPlugin(econ);
 
         EzShopsPlugin plugin = loadPlugin(EzShopsPlugin.class);
         ShopPricingManager pm = getPricingManager(plugin);
 
-        assertFalse(pm.getPrice(Material.OAK_PLANKS).isPresent(),
-                "OAK_PLANKS is not in the bundled config and should not be priced");
+        Optional<ShopPrice> price = pm.getPrice(Material.OAK_PLANKS);
+        assertTrue(price.isPresent(),
+                "OAK_PLANKS must be present in the price map after loading the bundled building.yml");
+        assertTrue(price.get().canSell(),
+                "OAK_PLANKS must have a positive sell price");
     }
 
     // -----------------------------------------------------------------------

--- a/src/test/java/com/skyblockexp/ezshops/shop/command/SellHandCommandFeatureTest.java
+++ b/src/test/java/com/skyblockexp/ezshops/shop/command/SellHandCommandFeatureTest.java
@@ -1,0 +1,97 @@
+package com.skyblockexp.ezshops.shop.command;
+
+import com.skyblockexp.ezshops.AbstractEzShopsTest;
+import com.skyblockexp.ezshops.EzShopsPlugin;
+import com.skyblockexp.ezshops.bootstrap.CoreShopComponent;
+import com.skyblockexp.ezshops.shop.ShopTransactionService;
+import net.milkbowl.vault.economy.Economy;
+import net.milkbowl.vault.economy.EconomyResponse;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
+
+import java.lang.reflect.Field;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Feature tests for the {@code /sellhand} command executor, verifying that
+ * the full command pipeline (permission check → pricing lookup → economy
+ * deposit) works correctly end-to-end for birch logs.
+ */
+public class SellHandCommandFeatureTest extends AbstractEzShopsTest {
+
+    @Test
+    void sellhand_birch_log_succeeds() throws Exception {
+        Economy econ = mock(Economy.class);
+        when(econ.format(anyDouble())).thenReturn("$0.00");
+        when(econ.depositPlayer(any(org.bukkit.OfflinePlayer.class), anyDouble()))
+                .thenReturn(new EconomyResponse(0, 1000, EconomyResponse.ResponseType.SUCCESS, ""));
+        loadProviderPlugin(econ);
+
+        EzShopsPlugin plugin = loadPlugin(EzShopsPlugin.class);
+        SellHandCommand cmd = getSellHandCommand(plugin);
+
+        PlayerMock player = server.addPlayer("birch-hand-seller");
+        player.addAttachment(plugin, ShopTransactionService.PERMISSION_SELL, true);
+        player.getInventory().setItemInMainHand(new ItemStack(Material.BIRCH_LOG, 32));
+
+        boolean handled = cmd.onCommand(player, null, "sellhand", new String[]{});
+
+        assertTrue(handled);
+        String message = player.nextMessage();
+        assertNotNull(message, "Player should receive a response message");
+        verify(econ, atLeastOnce()).depositPlayer(eq(player), anyDouble());
+    }
+
+    @Test
+    void sellhand_birch_log_fails_without_permission() throws Exception {
+        Economy econ = mock(Economy.class);
+        loadProviderPlugin(econ);
+
+        EzShopsPlugin plugin = loadPlugin(EzShopsPlugin.class);
+        SellHandCommand cmd = getSellHandCommand(plugin);
+
+        PlayerMock player = server.addPlayer("no-perm-seller");
+        // no sell permission granted
+        player.getInventory().setItemInMainHand(new ItemStack(Material.BIRCH_LOG, 16));
+
+        cmd.onCommand(player, null, "sellhand", new String[]{});
+
+        verify(econ, never()).depositPlayer(any(org.bukkit.OfflinePlayer.class), anyDouble());
+    }
+
+    @Test
+    void sellhand_fails_when_hand_is_empty() throws Exception {
+        Economy econ = mock(Economy.class);
+        loadProviderPlugin(econ);
+
+        EzShopsPlugin plugin = loadPlugin(EzShopsPlugin.class);
+        SellHandCommand cmd = getSellHandCommand(plugin);
+
+        PlayerMock player = server.addPlayer("empty-hand-seller");
+        player.addAttachment(plugin, ShopTransactionService.PERMISSION_SELL, true);
+        // main hand is AIR by default
+
+        cmd.onCommand(player, null, "sellhand", new String[]{});
+
+        verify(econ, never()).depositPlayer(any(org.bukkit.OfflinePlayer.class), anyDouble());
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    private SellHandCommand getSellHandCommand(EzShopsPlugin plugin) throws Exception {
+        CoreShopComponent core = plugin.getCoreShopComponent();
+        assertNotNull(core, "CoreShopComponent must not be null");
+        Field f = CoreShopComponent.class.getDeclaredField("sellHandCommand");
+        f.setAccessible(true);
+        SellHandCommand cmd = (SellHandCommand) f.get(core);
+        assertNotNull(cmd, "SellHandCommand must not be null");
+        return cmd;
+    }
+}


### PR DESCRIPTION
When items are shift-clicked into the Quick Sell GUI they are moved out of the player's own inventory. The previous `handleConfirm()` called `transactionService.sell()`, which ran `countMaterial(player, material)` against the player's inventory - returning 0 and causing 'Nothing to sell'.

Add `ShopTransactionService.sellDirect(Player, Material, int)` that skips the `countMaterial` / `removeItems` steps because the caller already owns and manages the items. Change `handleConfirm()` to use `sellDirect()`.

Add QuickSellMenuShiftClickTest with two regression tests:
- confirm_sells_items_present_only_in_gui_not_in_player_inventory
- confirm_sells_multiple_stacks_in_gui_at_once