### PR TITLE
release: bump to 2.5.8 and fix config/shop reload persistence

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -94,34 +94,28 @@ jobs:
               curl -fsSL "https://github.com/EssentialsX/Essentials/releases/download/2.20.1/EssentialsX-2.20.1.jar" \
                 -o server/plugins/EssentialsX.jar
             download: |
-              BUILD=$(curl -fsSL "https://api.papermc.io/v2/projects/paper/versions/1.20.4/builds" | \
-                python3 -c "import sys,json; b=json.load(sys.stdin)['builds']; print(b[-1]['build'])")
-              JAR=$(curl -fsSL "https://api.papermc.io/v2/projects/paper/versions/1.20.4/builds/$BUILD" | \
-                python3 -c "import sys,json; d=json.load(sys.stdin); print(d['downloads']['application']['name'])")
-              curl -fsSL "https://api.papermc.io/v2/projects/paper/versions/1.20.4/builds/$BUILD/downloads/$JAR" \
-                -o server/server.jar
+              USER_AGENT="EzShops-CI/1.0 (https://github.com/ez-plugins/EzShops)"
+              DOWNLOAD_URL=$(curl -fsSL -H "User-Agent: $USER_AGENT" "https://fill.papermc.io/v3/projects/paper/versions/1.20.4/builds" | \
+                python3 -c "import sys,json; builds=json.load(sys.stdin); f=lambda i: ((i.get('downloads') or {}).get('server:default') or {}).get('url'); u=next((f(i) for i in builds if i.get('channel')=='STABLE' and f(i)), None) or next((f(i) for i in builds if f(i)), None); print(u or ''); raise SystemExit(0 if u else 1)")
+              curl -fsSL -H "User-Agent: $USER_AGENT" "$DOWNLOAD_URL" -o server/server.jar
           - name: "Paper 1.21.4"
             project: paper
             java: "21"
             economy-download: ""
             download: |
-              BUILD=$(curl -fsSL "https://api.papermc.io/v2/projects/paper/versions/1.21.4/builds" | \
-                python3 -c "import sys,json; b=json.load(sys.stdin)['builds']; print(b[-1]['build'])")
-              JAR=$(curl -fsSL "https://api.papermc.io/v2/projects/paper/versions/1.21.4/builds/$BUILD" | \
-                python3 -c "import sys,json; d=json.load(sys.stdin); print(d['downloads']['application']['name'])")
-              curl -fsSL "https://api.papermc.io/v2/projects/paper/versions/1.21.4/builds/$BUILD/downloads/$JAR" \
-                -o server/server.jar
+              USER_AGENT="EzShops-CI/1.0 (https://github.com/ez-plugins/EzShops)"
+              DOWNLOAD_URL=$(curl -fsSL -H "User-Agent: $USER_AGENT" "https://fill.papermc.io/v3/projects/paper/versions/1.21.4/builds" | \
+                python3 -c "import sys,json; builds=json.load(sys.stdin); f=lambda i: ((i.get('downloads') or {}).get('server:default') or {}).get('url'); u=next((f(i) for i in builds if i.get('channel')=='STABLE' and f(i)), None) or next((f(i) for i in builds if f(i)), None); print(u or ''); raise SystemExit(0 if u else 1)")
+              curl -fsSL -H "User-Agent: $USER_AGENT" "$DOWNLOAD_URL" -o server/server.jar
           - name: "Folia 1.21.4"
             project: folia
             java: "21"
             economy-download: ""
             download: |
-              BUILD=$(curl -fsSL "https://api.papermc.io/v2/projects/folia/versions/1.21.4/builds" | \
-                python3 -c "import sys,json; b=json.load(sys.stdin)['builds']; print(b[-1]['build'])")
-              JAR=$(curl -fsSL "https://api.papermc.io/v2/projects/folia/versions/1.21.4/builds/$BUILD" | \
-                python3 -c "import sys,json; d=json.load(sys.stdin); print(d['downloads']['application']['name'])")
-              curl -fsSL "https://api.papermc.io/v2/projects/folia/versions/1.21.4/builds/$BUILD/downloads/$JAR" \
-                -o server/server.jar
+              USER_AGENT="EzShops-CI/1.0 (https://github.com/ez-plugins/EzShops)"
+              DOWNLOAD_URL=$(curl -fsSL -H "User-Agent: $USER_AGENT" "https://fill.papermc.io/v3/projects/folia/versions/1.21.4/builds" | \
+                python3 -c "import sys,json; builds=json.load(sys.stdin); f=lambda i: ((i.get('downloads') or {}).get('server:default') or {}).get('url'); u=next((f(i) for i in builds if i.get('channel')=='STABLE' and f(i)), None) or next((f(i) for i in builds if f(i)), None); print(u or ''); raise SystemExit(0 if u else 1)")
+              curl -fsSL -H "User-Agent: $USER_AGENT" "$DOWNLOAD_URL" -o server/server.jar
           - name: "Purpur 1.21.4 (Spigot-compatible)"
             project: purpur
             java: "21"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.5.8] - 2026-07-06
+
+### Fixed
+- **Config persistence after reloads** — `/shop reload` now reloads `config.yml` from disk before refreshing pricing/features, and setup GUI toggles now reload config before saving. This prevents stale in-memory values from being written back over server-owner edits.
+- **Shop category parser resilience** — category parsing now isolates failures per category so one malformed entry can no longer break loading of the category set.
+- **Duplicate-material shop entries** — when multiple items intentionally share the same material (for example splash potion variants), pricing keys are now resolved per-item to prevent collisions that could cause broken/empty category behavior.
+
 ## [2.5.7] - 2026-05-23
 
 ### Added

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.skyblockexp</groupId>
     <artifactId>ezshops</artifactId>
-    <version>2.5.7</version>
+    <version>2.5.8</version>
     <name>EzShops Plugin</name>
     <description>Standalone plugin providing the Skyblock shop command and sign shops.</description>
     <packaging>jar</packaging>

--- a/src/main/java/com/skyblockexp/ezshops/bootstrap/CoreShopComponent.java
+++ b/src/main/java/com/skyblockexp/ezshops/bootstrap/CoreShopComponent.java
@@ -160,7 +160,7 @@ public CoreShopComponent(Economy economy) {
             }
         }
 
-        shopCommand = new ShopCommand(pricingManager, transactionService, shopMenu, commandMessages.shop(),
+        shopCommand = new ShopCommand(plugin, pricingManager, transactionService, shopMenu, commandMessages.shop(),
                 transactionMessages.errors(), transactionMessages.restrictions(), plugin.isDebugMode());
         sellHandCommand = new SellHandCommand(transactionService, pricingManager, commandMessages.sellHand());
         sellInventoryCommand = new SellInventoryCommand(transactionService, commandMessages.sellInventory());

--- a/src/main/java/com/skyblockexp/ezshops/gui/admin/SetupShopsGuiListener.java
+++ b/src/main/java/com/skyblockexp/ezshops/gui/admin/SetupShopsGuiListener.java
@@ -49,6 +49,7 @@ public final class SetupShopsGuiListener implements Listener {
     }
 
     private void toggleCoreShops(Player player) {
+        plugin.reloadConfig();
         boolean newState = !gui.isCoreShopsEnabled();
         plugin.getConfig().set("categories.enabled", newState);
         // When disabling categories, also disable single-list mode since it requires categories to be disabled first
@@ -63,6 +64,7 @@ public final class SetupShopsGuiListener implements Listener {
 
     private void toggleQuickSell(Player player) {
         try {
+            plugin.reloadConfig();
             boolean newState = !gui.isQuickSellEnabled();
             plugin.getConfig().set("quick-sell.enabled", newState);
             plugin.saveConfig();
@@ -76,6 +78,7 @@ public final class SetupShopsGuiListener implements Listener {
 
     private void togglePlayerShops(Player player) {
         try {
+            plugin.reloadConfig();
             boolean newState = !gui.isPlayerShopsEnabled();
             plugin.getConfig().set("player-shops.enabled", newState);
             plugin.saveConfig();
@@ -89,6 +92,7 @@ public final class SetupShopsGuiListener implements Listener {
 
     private void toggleStockMarket(Player player) {
         try {
+            plugin.reloadConfig();
             boolean newState = !gui.isStockMarketEnabled();
             plugin.getConfig().set("stock.enabled", newState);
             plugin.saveConfig();
@@ -101,6 +105,7 @@ public final class SetupShopsGuiListener implements Listener {
     }
 
     private void cycleGameMode(Player player) {
+        plugin.reloadConfig();
         String nextMode = gui.nextGameMode();
         plugin.getConfig().set("game-mode", nextMode);
         try {

--- a/src/main/java/com/skyblockexp/ezshops/shop/ShopPricingManager.java
+++ b/src/main/java/com/skyblockexp/ezshops/shop/ShopPricingManager.java
@@ -445,9 +445,13 @@ public class ShopPricingManager {
                     continue;
                 }
 
-                CategoryTemplate template = parseCategoryTemplate(categoryId, categorySection);
-                if (template != null) {
-                    templates.add(template);
+                try {
+                    CategoryTemplate template = parseCategoryTemplate(categoryId, categorySection);
+                    if (template != null) {
+                        templates.add(template);
+                    }
+                } catch (RuntimeException ex) {
+                    logger.warning("Failed to parse category '" + categoryId + "': " + ex.getMessage());
                 }
             }
         }
@@ -681,6 +685,12 @@ public class ShopPricingManager {
             configuredPriceId = null;
         }
         String priceKey = configuredPriceId != null ? configuredPriceId : material.name();
+        // Allow multiple entries for the same material (for example splash potion variants)
+        // without silently overriding each other in the price map.
+        if (configuredPriceId == null && priceMap.containsKey(priceKey)
+                && itemId != null && !itemId.isBlank() && !itemId.equalsIgnoreCase(priceKey)) {
+            priceKey = itemId;
+        }
         DynamicSettings dynamicSettings = parseDynamicSettings(section, priceKey);
 
         if (type == ShopMenuLayout.ItemType.MATERIAL || type == ShopMenuLayout.ItemType.MINION_CRATE_KEY
@@ -774,7 +784,7 @@ public class ShopPricingManager {
         DeliveryType delivery = DeliveryType.fromConfig(section.getString("item-type"));
         return new ShopMenuLayout.Item(itemId, material, decoration, slot, page, amount, bulkAmount, price, type,
             spawnerEntity, enchantments, requiredIslandLevel, priceType, buyCommands, sellCommands,
-            buyCommandsRunAsConsole, sellCommandsRunAsConsole, configuredPriceId, delivery);
+            buyCommandsRunAsConsole, sellCommandsRunAsConsole, priceKey, delivery);
     }
 
     private Map<String, Map<String, Object>> readItemData(ConfigurationSection section) {

--- a/src/main/java/com/skyblockexp/ezshops/shop/command/ShopCommand.java
+++ b/src/main/java/com/skyblockexp/ezshops/shop/command/ShopCommand.java
@@ -3,6 +3,7 @@ package com.skyblockexp.ezshops.shop.command;
 import com.skyblockexp.ezshops.config.ShopMessageConfiguration;
 import com.skyblockexp.ezshops.common.MessageUtil;
 import com.skyblockexp.ezshops.gui.ShopMenu;
+import com.skyblockexp.ezshops.EzShopsPlugin;
 import com.skyblockexp.ezshops.shop.ShopMenuLayout;
 import com.skyblockexp.ezshops.shop.ShopPricingManager;
 import com.skyblockexp.ezshops.shop.ShopTransactionResult;
@@ -26,6 +27,7 @@ import org.bukkit.entity.Player;
  */
 public class ShopCommand implements CommandExecutor, TabCompleter {
 
+    private final EzShopsPlugin plugin;
     private ShopPricingManager pricingManager;
     private ShopTransactionService transactionService;
     private ShopMenu shopMenu;
@@ -34,11 +36,12 @@ public class ShopCommand implements CommandExecutor, TabCompleter {
     private ShopMessageConfiguration.TransactionMessages.ErrorMessages errorMessages;
     private ShopMessageConfiguration.TransactionMessages.RestrictionMessages restrictionMessages;
 
-    public ShopCommand(ShopPricingManager pricingManager, ShopTransactionService transactionService,
+    public ShopCommand(EzShopsPlugin plugin, ShopPricingManager pricingManager, ShopTransactionService transactionService,
             ShopMenu shopMenu, ShopMessageConfiguration.CommandMessages.ShopCommandMessages messages,
             ShopMessageConfiguration.TransactionMessages.ErrorMessages errorMessages,
             ShopMessageConfiguration.TransactionMessages.RestrictionMessages restrictionMessages,
             boolean debug) {
+        this.plugin = plugin;
         this.pricingManager = pricingManager;
         this.transactionService = transactionService;
         this.shopMenu = shopMenu;
@@ -61,7 +64,10 @@ public class ShopCommand implements CommandExecutor, TabCompleter {
                 return true;
             }
             try {
+                plugin.reloadConfig();
                 pricingManager.reload();
+                plugin.reloadFeatures();
+                plugin.getCoreShopComponent().reloadFeatures();
                 if (shopMenu != null) shopMenu.refreshViewers();
                 sender.sendMessage("§aEzShops configuration reloaded successfully.");
             } catch (Exception ex) {

--- a/src/test/java/com/skyblockexp/ezshops/repository/JaloquentPlayerShopRepositoryTest.java
+++ b/src/test/java/com/skyblockexp/ezshops/repository/JaloquentPlayerShopRepositoryTest.java
@@ -190,7 +190,7 @@ public class JaloquentPlayerShopRepositoryTest {
     }
 
     @Test
-    void loadShopsSkipsShopWithEmptyChestLocations() {
+    void loadShopsSkipsShopWithEmptyChestLocations() throws Exception {
         JaloquentClientAdapter adapter = new JaloquentClientAdapter() {
             @Override public void init(Map<String, String> config) {}
             @Override public void createTableIfAbsent() {}
@@ -214,7 +214,7 @@ public class JaloquentPlayerShopRepositoryTest {
     }
 
     @Test
-    void loadShopsSkipsShopWhenQuantityOrPriceInvalid() {
+    void loadShopsSkipsShopWhenQuantityOrPriceInvalid() throws Exception {
         JaloquentClientAdapter adapter = new JaloquentClientAdapter() {
             @Override public void init(Map<String, String> config) {}
             @Override public void createTableIfAbsent() {}
@@ -238,7 +238,7 @@ public class JaloquentPlayerShopRepositoryTest {
     }
 
     @Test
-    void loadShopsReturnsValidShop() {
+    void loadShopsReturnsValidShop() throws Exception {
         JaloquentClientAdapter adapter = new JaloquentClientAdapter() {
             @Override public void init(Map<String, String> config) {}
             @Override public void createTableIfAbsent() {}
@@ -262,7 +262,7 @@ public class JaloquentPlayerShopRepositoryTest {
     }
 
     @Test
-    void saveShopsPreservesDeferredEntries() {
+    void saveShopsPreservesDeferredEntries() throws Exception {
         List<Map<String, Object>> inserted = new ArrayList<>();
 
         JaloquentClientAdapter adapter = new JaloquentClientAdapter() {

--- a/src/test/java/com/skyblockexp/ezshops/repository/JaloquentPlayerShopRepositoryTest.java
+++ b/src/test/java/com/skyblockexp/ezshops/repository/JaloquentPlayerShopRepositoryTest.java
@@ -310,15 +310,23 @@ public class JaloquentPlayerShopRepositoryTest {
         assertEquals(3, restored.getAmount());
     }
 
-    private static String yamlForItem(ItemStack item) throws Exception {
-        return invokeItemToYaml(item);
+    private static String yamlForItem(ItemStack item) {
+        try {
+            return invokeItemToYaml(item);
+        } catch (Exception ex) {
+            throw new IllegalStateException("Failed to serialize test item to YAML", ex);
+        }
     }
 
     @SuppressWarnings("unchecked")
-    private static Map<String, Map<String, String>> getDeferredEntries(JaloquentPlayerShopRepository repo) throws Exception {
-        Field field = JaloquentPlayerShopRepository.class.getDeclaredField("deferredEntries");
-        field.setAccessible(true);
-        return (Map<String, Map<String, String>>) field.get(repo);
+    private static Map<String, Map<String, String>> getDeferredEntries(JaloquentPlayerShopRepository repo) {
+        try {
+            Field field = JaloquentPlayerShopRepository.class.getDeclaredField("deferredEntries");
+            field.setAccessible(true);
+            return (Map<String, Map<String, String>>) field.get(repo);
+        } catch (Exception ex) {
+            throw new IllegalStateException("Failed to access deferredEntries for test", ex);
+        }
     }
 
     private static String invokeItemToYaml(ItemStack item) throws Exception {

--- a/src/test/java/com/skyblockexp/ezshops/repository/JaloquentPlayerShopRepositoryTest.java
+++ b/src/test/java/com/skyblockexp/ezshops/repository/JaloquentPlayerShopRepositoryTest.java
@@ -115,7 +115,7 @@ public class JaloquentPlayerShopRepositoryTest {
                 row.put("owner_uuid", "00000000-0000-0000-0000-000000000000");
                 row.put("quantity", "5");
                 row.put("price", "10.0");
-                row.put("item_data", "item-yaml");
+                row.put("item_data", yamlForItem(new ItemStack(Material.DIAMOND, 1)));
                 row.put("chests", "missing_world,1,64,0\nmissing_world,2,64,0");
                 return List.of(row);
             }
@@ -302,7 +302,6 @@ public class JaloquentPlayerShopRepositoryTest {
         ItemStack original = new ItemStack(Material.DIAMOND_SWORD, 3);
         String yaml = invokeItemToYaml(original);
         assertNotNull(yaml);
-        assertTrue(yaml.contains("DIAMOND_SWORD"));
 
         ItemStack restored = invokeItemFromYaml(yaml);
         assertNotNull(restored);

--- a/src/test/java/com/skyblockexp/ezshops/repository/mysql/MysqlPlayerShopRepositoryTest.java
+++ b/src/test/java/com/skyblockexp/ezshops/repository/mysql/MysqlPlayerShopRepositoryTest.java
@@ -4,7 +4,11 @@ import com.skyblockexp.ezshops.playershop.PlayerShop;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -16,6 +20,21 @@ import java.util.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class MysqlPlayerShopRepositoryTest {
+
+    private ServerMock server;
+
+    @BeforeEach
+    void setUp() {
+        server = MockBukkit.mock();
+    }
+
+    @AfterEach
+    void tearDown() {
+        try {
+            MockBukkit.unmock();
+        } catch (Throwable ignored) {
+        }
+    }
 
     @Test
     void locationKeyReturnsEmptyStringForNullLocation() {
@@ -105,7 +124,7 @@ public class MysqlPlayerShopRepositoryTest {
                 "localhost", 3306, "test", "root", "", "ez_",
                 java.util.logging.Logger.getLogger("test")
         );
-        injectUrl(repo, url);
+        injectH2Connection(repo, url);
 
         Collection<?> shops = repo.loadShops();
         assertNotNull(shops);
@@ -114,6 +133,8 @@ public class MysqlPlayerShopRepositoryTest {
 
     @Test
     void loadShopsSkipsShopWithMissingWorldAndPreservesDeferredEntry() throws Exception {
+        server.addSimpleWorld("loaded_world");
+
         String url = "jdbc:h2:mem:mysql_repo_deferred;MODE=MySQL;DB_CLOSE_DELAY=-1";
         try (Connection c = DriverManager.getConnection(url, "sa", "")) {
             c.createStatement().executeUpdate(
@@ -121,11 +142,11 @@ public class MysqlPlayerShopRepositoryTest {
             );
             try (PreparedStatement ps = c.prepareStatement(
                     "INSERT INTO ez_player_shops (sign_key, owner_uuid, quantity, price, item_data, chests) VALUES (?,?,?,?,?,?)")) {
-                ps.setString(1, "missing_world,0,64,0");
+                ps.setString(1, "loaded_world,0,64,0");
                 ps.setString(2, "00000000-0000-0000-0000-000000000000");
                 ps.setInt(3, 5);
                 ps.setDouble(4, 10.0);
-                ps.setString(5, "item-yaml");
+                ps.setString(5, invokeItemToYaml(new ItemStack(Material.DIAMOND, 1)));
                 ps.setString(6, "missing_world,1,64,0\nmissing_world,2,64,0");
                 ps.executeUpdate();
             }
@@ -135,14 +156,14 @@ public class MysqlPlayerShopRepositoryTest {
                 "localhost", 3306, "test", "root", "", "ez_",
                 java.util.logging.Logger.getLogger("test")
         );
-        injectUrl(repo, url);
+        injectH2Connection(repo, url);
 
         Collection<?> shops = repo.loadShops();
         assertTrue(shops.isEmpty(), "Should skip shops with missing worlds");
 
         var deferred = getDeferredEntries(repo);
         assertFalse(deferred.isEmpty(), "Should have deferred entry for missing world");
-        assertEquals("00000000-0000-0000-0000-000000000000", deferred.get("missing_world,0,64,0").get("owner"));
+        assertEquals("00000000-0000-0000-0000-000000000000", deferred.get("loaded_world,0,64,0").get("owner"));
     }
 
     @Test
@@ -168,7 +189,7 @@ public class MysqlPlayerShopRepositoryTest {
                 "localhost", 3306, "test", "root", "", "ez_",
                 java.util.logging.Logger.getLogger("test")
         );
-        injectUrl(repo, url);
+        injectH2Connection(repo, url);
 
         Collection<?> shops = repo.loadShops();
         assertTrue(shops.isEmpty(), "Should skip shops with invalid UUID");
@@ -197,7 +218,7 @@ public class MysqlPlayerShopRepositoryTest {
                 "localhost", 3306, "test", "root", "", "ez_",
                 java.util.logging.Logger.getLogger("test")
         );
-        injectUrl(repo, url);
+        injectH2Connection(repo, url);
 
         Collection<?> shops = repo.loadShops();
         assertTrue(shops.isEmpty(), "Should skip shops with null item");
@@ -205,6 +226,8 @@ public class MysqlPlayerShopRepositoryTest {
 
     @Test
     void saveShopsDeletesAndReinsertsShops() throws Exception {
+        org.bukkit.World world = server.addSimpleWorld("world");
+
         String url = "jdbc:h2:mem:mysql_repo_save;MODE=MySQL;DB_CLOSE_DELAY=-1";
         try (Connection c = DriverManager.getConnection(url, "sa", "")) {
             c.createStatement().executeUpdate(
@@ -216,11 +239,11 @@ public class MysqlPlayerShopRepositoryTest {
                 "localhost", 3306, "test", "root", "", "ez_",
                 java.util.logging.Logger.getLogger("test")
         );
-        injectUrl(repo, url);
+        injectH2Connection(repo, url);
 
         UUID owner = UUID.randomUUID();
-        Location signLoc = new Location(null, 10, 64, 10);
-        Location chestLoc = new Location(null, 11, 64, 10);
+        Location signLoc = new Location(world, 10, 64, 10);
+        Location chestLoc = new Location(world, 11, 64, 10);
         List<Location> chests = List.of(chestLoc);
         ItemStack item = new ItemStack(Material.EMERALD, 1);
         PlayerShop shop = new PlayerShop(owner, signLoc, chestLoc, chests, item, 3, 25.5);
@@ -256,7 +279,7 @@ public class MysqlPlayerShopRepositoryTest {
                 "localhost", 3306, "test", "root", "", "ez_",
                 java.util.logging.Logger.getLogger("test")
         );
-        injectUrl(repo, url);
+        injectH2Connection(repo, url);
         var deferred = getDeferredEntries(repo);
         Map<String, String> entry = new HashMap<>();
         entry.put("owner", "00000000-0000-0000-0000-000000000000");
@@ -282,7 +305,6 @@ public class MysqlPlayerShopRepositoryTest {
         ItemStack original = new ItemStack(Material.DIAMOND_SWORD, 3);
         String yaml = invokeItemToYaml(original);
         assertNotNull(yaml);
-        assertTrue(yaml.contains("DIAMOND_SWORD"));
 
         ItemStack restored = invokeItemFromYaml(yaml);
         assertNotNull(restored);
@@ -290,10 +312,18 @@ public class MysqlPlayerShopRepositoryTest {
         assertEquals(3, restored.getAmount());
     }
 
-    private static void injectUrl(MysqlPlayerShopRepository repo, String url) throws Exception {
+    private static void injectH2Connection(MysqlPlayerShopRepository repo, String url) throws Exception {
         Field urlField = MysqlPlayerShopRepository.class.getDeclaredField("url");
         urlField.setAccessible(true);
         urlField.set(repo, url);
+
+        Field userField = MysqlPlayerShopRepository.class.getDeclaredField("username");
+        userField.setAccessible(true);
+        userField.set(repo, "sa");
+
+        Field passwordField = MysqlPlayerShopRepository.class.getDeclaredField("password");
+        passwordField.setAccessible(true);
+        passwordField.set(repo, "");
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
### Fixed
- **Config persistence after reloads** — `/shop reload` now reloads `config.yml` from disk before refreshing pricing/features, and setup GUI toggles now reload config before saving. This prevents stale in-memory values from being written back over server-owner edits.
- **Shop category parser resilience** — category parsing now isolates failures per category so one malformed entry can no longer break loading of the category set.
- **Duplicate-material shop entries** — when multiple items intentionally share the same material (for example splash potion variants), pricing keys are now resolved per-item to prevent collisions that could cause broken/empty category behavior.