### PR TITLE
fix(bootstrap): disable cleanly when Vault has no economy provider

### DIFF
--- a/src/main/java/com/skyblockexp/ezshops/bootstrap/EzShopsBootstrap.java
+++ b/src/main/java/com/skyblockexp/ezshops/bootstrap/EzShopsBootstrap.java
@@ -208,12 +208,17 @@ public final class EzShopsBootstrap {
     private boolean setupEconomy() {
         RegisteredServiceProvider<Economy> registration =
                 plugin.getServer().getServicesManager().getRegistration(Economy.class);
-        if (registration != null) {
-            economy = registration.getProvider();
-            return economy != null;
+        if (registration == null) {
+            plugin.getLogger().severe("No Vault economy provider is registered. Install an economy "
+                    + "plugin that provides a Vault economy service (e.g. EssentialsX, CMI).");
+            return false;
         }
-
-        return plugin.getServer().getPluginManager().getPlugin("Vault") != null;
+        economy = registration.getProvider();
+        if (economy == null) {
+            plugin.getLogger().severe("Vault registered a null economy provider.");
+            return false;
+        }
+        return true;
     }
 
     private void saveDefaultResources() {

--- a/src/main/java/com/skyblockexp/ezshops/bootstrap/PlayerShopComponent.java
+++ b/src/main/java/com/skyblockexp/ezshops/bootstrap/PlayerShopComponent.java
@@ -118,7 +118,7 @@ public final class PlayerShopComponent implements PluginComponent {
                 plugin.getLogger().info("Player shops: using Jaloquent storage (JDBC adapter).");
                 return repo;
             } catch (Exception ex) {
-                plugin.getLogger().severe("Failed to initialise Jaloquent for player shops; falling back to YAML. " + ex.getMessage());
+                plugin.getLogger().warning("Failed to initialise Jaloquent for player shops; falling back to YAML. " + ex.getMessage());
             }
         }
         if ("mysql".equalsIgnoreCase(type)) {
@@ -136,7 +136,7 @@ public final class PlayerShopComponent implements PluginComponent {
                 plugin.getLogger().info("Player shops: using MySQL storage.");
                 return repo;
             } catch (IllegalStateException ex) {
-                plugin.getLogger().severe("Failed to connect to MySQL for player shops; falling back to YAML. " + ex.getMessage());
+                plugin.getLogger().warning("Failed to connect to MySQL for player shops; falling back to YAML. " + ex.getMessage());
             }
         }
         return new YmlPlayerShopRepository(plugin.getDataFolder(), plugin.getLogger());

--- a/src/test/java/com/skyblockexp/ezshops/AbstractEzShopsTest.java
+++ b/src/test/java/com/skyblockexp/ezshops/AbstractEzShopsTest.java
@@ -101,6 +101,27 @@ public abstract class AbstractEzShopsTest {
         }
     }
 
+    /**
+     * Load a minimal plugin with the given name that registers no services.
+     * Used to simulate an environment where a hard dependency (e.g. Vault) is
+     * present but no economy provider is registered.
+     */
+    protected void loadBarePlugin(String name) {
+        try {
+            PluginDescriptionFile description = new PluginDescriptionFile(
+                    name, "1.0", BarePlugin.class.getName());
+            File dataFolder = Files.createTempDirectory("test-plugin-" + name).toFile();
+            BarePlugin plugin = (BarePlugin) getUnsafe().allocateInstance(BarePlugin.class);
+            plugin.init(server, description, dataFolder, new File(""),
+                    BarePlugin.class.getClassLoader(), description,
+                    Logger.getLogger(name));
+            server.getPluginManager().registerLoadedPlugin(plugin);
+            server.getPluginManager().enablePlugin(plugin);
+        } catch (IOException | InstantiationException e) {
+            throw new RuntimeException("Failed to load bare plugin " + name, e);
+        }
+    }
+
     private static Unsafe getUnsafe() {
         try {
             Field field = Unsafe.class.getDeclaredField("theUnsafe");
@@ -108,6 +129,13 @@ public abstract class AbstractEzShopsTest {
             return (Unsafe) field.get(null);
         } catch (ReflectiveOperationException e) {
             throw new RuntimeException("Cannot access Unsafe", e);
+        }
+    }
+
+    public static class BarePlugin extends JavaPlugin {
+        @Override
+        public void onEnable() {
+            // Intentionally registers no services.
         }
     }
 

--- a/src/test/java/com/skyblockexp/ezshops/EzShopsSetupEconomyFeatureTest.java
+++ b/src/test/java/com/skyblockexp/ezshops/EzShopsSetupEconomyFeatureTest.java
@@ -17,4 +17,16 @@ public class EzShopsSetupEconomyFeatureTest extends AbstractEzShopsTest {
         assertNotNull(plugin);
         assertTrue(plugin.isEnabled(), "EzShops should enable when an Economy provider is registered in ServicesManager");
     }
+
+    @Test
+    void missingEconomyProvider_disablesPluginCleanly() {
+        // Vault present but no economy provider registered. This used to NPE in
+        // PlayerShopComponent.<init> because setupEconomy() returned true while
+        // the economy field was still null.
+        loadBarePlugin("Vault");
+
+        EzShopsPlugin plugin = assertDoesNotThrow(() -> loadPlugin(EzShopsPlugin.class));
+        assertFalse(plugin.isEnabled(),
+                "EzShops should disable cleanly when Vault has no economy provider");
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #79 — EzShops no longer crashes with a `NullPointerException` on startup when Vault is present but no economy provider is registered.

## Changes

- `EzShopsBootstrap.setupEconomy()`: check `getRegistration(Economy.class)` first; when no provider is registered, log a clear message ("Install an economy plugin that provides a Vault economy service") and return `false` so the plugin disables itself cleanly.
- `PlayerShopComponent`: downgrade the non-fatal DB-fallback logs (Jaloquent / MySQL connection failures) from `SEVERE` to `WARNING`.
- Tests (`EzShopsSetupEconomyFeatureTest`): cover both "economy provider registered → plugin enables" and "Vault present but no provider → plugin disables cleanly".

## Testing

- Local (MockBukkit tests skipped by version assumption): `mvn test -Dpaper.version=1.21.3-R0.1-SNAPSHOT`
- Full MockBukkit run: `mvn test -Dpaper.version=1.21.11-R0.1-SNAPSHOT` — both new tests pass.

Closes #79
